### PR TITLE
Build in log sink functionality.

### DIFF
--- a/.changelog/9.txt
+++ b/.changelog/9.txt
@@ -1,0 +1,11 @@
+```release-note:breaking-change
+Provider log outputs now default to being named "provider" unless another name is provided.
+```
+
+```release-note:feature
+Added a `tfsdklog.RegisterSink` function that will turn on a logging sink. When a logging sink is activated, all downstream provider and SDK loggers (i.e., all loggers created after `tfsdklog.RegisterSink` is called) will be sub-loggers of the sink. The sink respects the `TF_LOG` and `TF_LOG_PATH` environment variables, by default discards logs, and when `TF_LOG` is set writes to stderr. It is meant to replicate Terraform's log aggregation and filtering capabilities for test frameworks.
+```
+
+```release-note:feature
+Added a `tfsdklog.PipeJSONLogs` function that can consume the JSON-formatted log output from Terraform and pipe it into the sink, allowing test frameworks to merge logs from the provider under test, the providers run by Terraform, and Terraform itself.
+```

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/terraform-plugin-log
 go 1.16
 
 require (
+	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/go-hclog v0.16.1
 	github.com/stretchr/testify v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hashicorp/go-hclog v0.16.1 h1:IVQwpTGNRRIHafnTs2dQLIk4ENtneRIEEJWOVDqz99o=
 github.com/hashicorp/go-hclog v0.16.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
@@ -19,3 +21,5 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tflog/provider_example_test.go
+++ b/tflog/provider_example_test.go
@@ -33,7 +33,7 @@ func ExampleWith() {
 	Trace(derivedCtx, "example log message")
 
 	// Output:
-	// {"@level":"trace","@message":"example log message","foo":123}
+	// {"@level":"trace","@message":"example log message","@module":"provider","foo":123}
 }
 
 func ExampleTrace() {
@@ -50,7 +50,7 @@ func ExampleTrace() {
 	Trace(exampleCtx, "hello, world", "foo", 123, "colors", []string{"red", "blue", "green"})
 
 	// Output:
-	// {"@level":"trace","@message":"hello, world","colors":["red","blue","green"],"foo":123}
+	// {"@level":"trace","@message":"hello, world","@module":"provider","colors":["red","blue","green"],"foo":123}
 }
 
 func ExampleDebug() {
@@ -67,7 +67,7 @@ func ExampleDebug() {
 	Debug(exampleCtx, "hello, world", "foo", 123, "colors", []string{"red", "blue", "green"})
 
 	// Output:
-	// {"@level":"debug","@message":"hello, world","colors":["red","blue","green"],"foo":123}
+	// {"@level":"debug","@message":"hello, world","@module":"provider","colors":["red","blue","green"],"foo":123}
 }
 
 func ExampleInfo() {
@@ -84,7 +84,7 @@ func ExampleInfo() {
 	Info(exampleCtx, "hello, world", "foo", 123, "colors", []string{"red", "blue", "green"})
 
 	// Output:
-	// {"@level":"info","@message":"hello, world","colors":["red","blue","green"],"foo":123}
+	// {"@level":"info","@message":"hello, world","@module":"provider","colors":["red","blue","green"],"foo":123}
 }
 
 func ExampleWarn() {
@@ -101,7 +101,7 @@ func ExampleWarn() {
 	Warn(exampleCtx, "hello, world", "foo", 123, "colors", []string{"red", "blue", "green"})
 
 	// Output:
-	// {"@level":"warn","@message":"hello, world","colors":["red","blue","green"],"foo":123}
+	// {"@level":"warn","@message":"hello, world","@module":"provider","colors":["red","blue","green"],"foo":123}
 }
 
 func ExampleError() {
@@ -118,5 +118,5 @@ func ExampleError() {
 	Error(exampleCtx, "hello, world", "foo", 123, "colors", []string{"red", "blue", "green"})
 
 	// Output:
-	// {"@level":"error","@message":"hello, world","colors":["red","blue","green"],"foo":123}
+	// {"@level":"error","@message":"hello, world","@module":"provider","colors":["red","blue","green"],"foo":123}
 }

--- a/tflog/subsystem_example_test.go
+++ b/tflog/subsystem_example_test.go
@@ -22,7 +22,7 @@ func ExampleNewSubsystem() {
 	SubsystemTrace(subCtx, "my-subsystem", "hello, world", "foo", 123)
 
 	// Output:
-	// {"@level":"trace","@message":"hello, world","@module":"my-subsystem","foo":123}
+	// {"@level":"trace","@message":"hello, world","@module":"provider.my-subsystem","foo":123}
 }
 
 func ExampleNewSubsystem_withLevel() {
@@ -56,8 +56,8 @@ func ExampleNewSubsystem_withLevel() {
 	SubsystemWarn(subCtx, "my-subsystem", "hello, world", "foo", 123)
 
 	// Output:
-	// {"@level":"trace","@message":"hello, world","foo":123}
-	// {"@level":"warn","@message":"hello, world","@module":"my-subsystem","foo":123}
+	// {"@level":"trace","@message":"hello, world","@module":"provider","foo":123}
+	// {"@level":"warn","@message":"hello, world","@module":"provider.my-subsystem","foo":123}
 }
 
 func ExampleSubsystemWith() {
@@ -83,7 +83,7 @@ func ExampleSubsystemWith() {
 	SubsystemTrace(derivedCtx, "my-subsystem", "example log message")
 
 	// Output:
-	// {"@level":"trace","@message":"example log message","@module":"my-subsystem","foo":123}
+	// {"@level":"trace","@message":"example log message","@module":"provider.my-subsystem","foo":123}
 }
 
 func ExampleSubsystemTrace() {
@@ -103,7 +103,7 @@ func ExampleSubsystemTrace() {
 	SubsystemTrace(exampleCtx, "my-subsystem", "hello, world", "foo", 123, "colors", []string{"red", "blue", "green"})
 
 	// Output:
-	// {"@level":"trace","@message":"hello, world","@module":"my-subsystem","colors":["red","blue","green"],"foo":123}
+	// {"@level":"trace","@message":"hello, world","@module":"provider.my-subsystem","colors":["red","blue","green"],"foo":123}
 }
 
 func ExampleSubsystemDebug() {
@@ -123,7 +123,7 @@ func ExampleSubsystemDebug() {
 	SubsystemDebug(exampleCtx, "my-subsystem", "hello, world", "foo", 123, "colors", []string{"red", "blue", "green"})
 
 	// Output:
-	// {"@level":"debug","@message":"hello, world","@module":"my-subsystem","colors":["red","blue","green"],"foo":123}
+	// {"@level":"debug","@message":"hello, world","@module":"provider.my-subsystem","colors":["red","blue","green"],"foo":123}
 }
 
 func ExampleSubsystemInfo() {
@@ -143,7 +143,7 @@ func ExampleSubsystemInfo() {
 	SubsystemInfo(exampleCtx, "my-subsystem", "hello, world", "foo", 123, "colors", []string{"red", "blue", "green"})
 
 	// Output:
-	// {"@level":"info","@message":"hello, world","@module":"my-subsystem","colors":["red","blue","green"],"foo":123}
+	// {"@level":"info","@message":"hello, world","@module":"provider.my-subsystem","colors":["red","blue","green"],"foo":123}
 }
 
 func ExampleSubsystemWarn() {
@@ -163,7 +163,7 @@ func ExampleSubsystemWarn() {
 	SubsystemWarn(exampleCtx, "my-subsystem", "hello, world", "foo", 123, "colors", []string{"red", "blue", "green"})
 
 	// Output:
-	// {"@level":"warn","@message":"hello, world","@module":"my-subsystem","colors":["red","blue","green"],"foo":123}
+	// {"@level":"warn","@message":"hello, world","@module":"provider.my-subsystem","colors":["red","blue","green"],"foo":123}
 }
 
 func ExampleSubsystemError() {
@@ -183,5 +183,5 @@ func ExampleSubsystemError() {
 	SubsystemError(exampleCtx, "my-subsystem", "hello, world", "foo", 123, "colors", []string{"red", "blue", "green"})
 
 	// Output:
-	// {"@level":"error","@message":"hello, world","@module":"my-subsystem","colors":["red","blue","green"],"foo":123}
+	// {"@level":"error","@message":"hello, world","@module":"provider.my-subsystem","colors":["red","blue","green"],"foo":123}
 }

--- a/tfsdklog/cli.go
+++ b/tfsdklog/cli.go
@@ -9,6 +9,12 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+// envLogCLI is the environment variable that users can set to control the
+// least-verbose level of logs that will be forwarded from the CLI. These logs
+// are a combination of the logs for the Terraform binary _and_ for the
+// provider binaries that are not under test.
+//
+// Valid values are TRACE, DEBUG, INFO, WARN, ERROR, and OFF.
 const envLogCLI = "TF_LOG_CLI"
 
 func newCLILogger(ctx context.Context, commandID string) hclog.Logger {

--- a/tfsdklog/cli.go
+++ b/tfsdklog/cli.go
@@ -1,0 +1,31 @@
+package tfsdklog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+const envLogCLI = "TF_LOG_CLI"
+
+func newCLILogger(ctx context.Context, commandID string) hclog.Logger {
+	sink := getSink(ctx)
+	if sink == nil {
+		return nil
+	}
+	l := sink.Named("terraform")
+	envLevel := strings.ToUpper(os.Getenv(envLog))
+	if envLevel != "" {
+		if isValidLogLevel(envLevel) {
+			l.SetLevel(hclog.LevelFromString(envLevel))
+		} else {
+			fmt.Fprintf(os.Stderr, "[WARN] Invalid log level for %s: %q. Defaulting to %s level. Valid levels are: %+v",
+				envLogCLI, envLevel, envLog, ValidLevels)
+		}
+	}
+	l = l.With("command_id", commandID)
+	return l
+}

--- a/tfsdklog/sdk.go
+++ b/tfsdklog/sdk.go
@@ -11,11 +11,18 @@ import (
 // configured with the passed options.
 func NewRootSDKLogger(ctx context.Context, options ...logging.Option) context.Context {
 	opts := logging.ApplyLoggerOpts(options...)
-	if opts.Level == hclog.NoLevel {
-		opts.Level = hclog.Trace
-	}
 	if opts.Name == "" {
 		opts.Name = "sdk"
+	}
+	if sink := getSink(ctx); sink != nil {
+		logger := sink.Named(opts.Name)
+		if opts.Level != hclog.NoLevel {
+			logger.SetLevel(opts.Level)
+		}
+		return logging.SetSDKRootLogger(ctx, logger)
+	}
+	if opts.Level == hclog.NoLevel {
+		opts.Level = hclog.Trace
 	}
 	loggerOptions := &hclog.LoggerOptions{
 		Name:                     opts.Name,
@@ -34,6 +41,16 @@ func NewRootSDKLogger(ctx context.Context, options ...logging.Option) context.Co
 // logger configured with the passed options.
 func NewRootProviderLogger(ctx context.Context, options ...logging.Option) context.Context {
 	opts := logging.ApplyLoggerOpts(options...)
+	if opts.Name == "" {
+		opts.Name = "provider"
+	}
+	if sink := getSink(ctx); sink != nil {
+		logger := sink.Named(opts.Name)
+		if opts.Level != hclog.NoLevel {
+			logger.SetLevel(opts.Level)
+		}
+		return logging.SetProviderSpaceRootLogger(ctx, logger)
+	}
 	if opts.Level == hclog.NoLevel {
 		opts.Level = hclog.Trace
 	}

--- a/tfsdklog/sdk.go
+++ b/tfsdklog/sdk.go
@@ -49,7 +49,7 @@ func NewRootProviderLogger(ctx context.Context, options ...logging.Option) conte
 		if opts.Level != hclog.NoLevel {
 			logger.SetLevel(opts.Level)
 		}
-		return logging.SetProviderSpaceRootLogger(ctx, logger)
+		return logging.SetProviderRootLogger(ctx, logger)
 	}
 	if opts.Level == hclog.NoLevel {
 		opts.Level = hclog.Trace

--- a/tfsdklog/sink.go
+++ b/tfsdklog/sink.go
@@ -13,7 +13,22 @@ import (
 )
 
 const (
-	envLog     = "TF_LOG"
+	// envLog is the environment variable that users can set to control the
+	// least-verbose level of logs that will be output during testing. If
+	// this environment variable is set, it will default to off. This is
+	// just the default; specific loggers and sub-loggers can set a lower
+	// or higher verbosity level without a problem right now. In theory,
+	// they should not be able to.
+	//
+	// Valid values are TRACE, DEBUG, INFO, WARN, ERROR, and OFF. A special
+	// pseudo-value, JSON, will set the value to TRACE and output the
+	// results in their JSON format.
+	envLog = "TF_LOG"
+
+	// envLogFile is the environment variable that controls where log
+	// output is written during tests. By default, logs will be written to
+	// standard error. Setting this environment variable to another file
+	// path will write logs there instead during tests.
 	envLogFile = "TF_LOG_PATH"
 )
 

--- a/tfsdklog/sink.go
+++ b/tfsdklog/sink.go
@@ -1,0 +1,96 @@
+package tfsdklog
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-log/internal/logging"
+)
+
+const (
+	envLog     = "TF_LOG"
+	envLogFile = "TF_LOG_PATH"
+)
+
+var sink hclog.Logger
+
+func init() {
+	sink = newSink()
+}
+
+// ValidLevels are the string representations of levels that can be set for
+// loggers.
+var ValidLevels = []string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF"}
+
+func getSink(ctx context.Context) hclog.Logger {
+	logger := ctx.Value(logging.SinkKey)
+	if logger == nil {
+		return nil
+	}
+	return logger.(hclog.Logger)
+}
+
+// RegisterSink sets up a logging sink, for use with test frameworks and other
+// cases where plugin logs don't get routed through Terraform. This applies the
+// same filtering and file output behaviors that Terraform does.
+//
+// RegisterSink should only ever be called by test frameworks, providers should
+// never call it.
+//
+// RegisterSink must be called prior to any loggers being setup or instantiated.
+func RegisterSink(ctx context.Context) context.Context {
+	return context.WithValue(ctx, logging.SinkKey, sink)
+}
+
+func newSink() hclog.Logger {
+	logOutput := io.Writer(os.Stderr)
+	var json bool
+	var logLevel hclog.Level
+
+	// if TF_LOG_PATH is set, output logs there
+	if logPath := os.Getenv(envLogFile); logPath != "" {
+		f, err := os.OpenFile(logPath, syscall.O_CREAT|syscall.O_RDWR|syscall.O_APPEND, 0666)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error opening log file: %v\n", err)
+		} else {
+			logOutput = f
+		}
+	}
+
+	// if TF_LOG is set, set the level
+	envLevel := strings.ToUpper(os.Getenv(envLog))
+	if envLevel == "" {
+		logLevel = hclog.Off
+	}
+	if envLevel == "JSON" {
+		logLevel = hclog.Trace
+		json = true
+	} else if isValidLogLevel(envLevel) {
+		logLevel = hclog.LevelFromString(envLevel)
+	} else {
+		fmt.Fprintf(os.Stderr, "[WARN] Invalid log level: %q. Defaulting to level: OFF. Valid levels are: %+v",
+			envLevel, ValidLevels)
+	}
+
+	return hclog.New(&hclog.LoggerOptions{
+		Level:             logLevel,
+		Output:            logOutput,
+		IndependentLevels: true,
+		JSONFormat:        json,
+	})
+}
+
+func isValidLogLevel(level string) bool {
+	for _, l := range ValidLevels {
+		if level == string(l) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tfsdklog/sink_json.go
+++ b/tfsdklog/sink_json.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"sort"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -157,6 +158,10 @@ func parseJSON(input []byte) (*logEntry, error) {
 			Value: v,
 		})
 	}
+
+	sort.Slice(entry.KVPairs, func(i, j int) bool {
+		return entry.KVPairs[i].Key < entry.KVPairs[j].Key
+	})
 
 	return entry, nil
 }

--- a/tfsdklog/sink_json.go
+++ b/tfsdklog/sink_json.go
@@ -1,0 +1,162 @@
+package tfsdklog
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+var stdErrBufferSize = 64 * 1024
+
+// PipeJSONLogs processes go-hclog-formatted JSON output from `r` and writes it
+// to `sink`, using any existing sub-loggers it can identify and falling back
+// on the cli sub-logger if no sub-logger matches the module for the log entry.
+// It will block until `ctx` is canceled.
+//
+// PipeJSONLogs is meant to be used to process output from a Terraform binary
+// run via terraform-exec, merging the logs from the provider under test with
+// the logs from Terraform and other providers.
+//
+// It is safe to run multiple instances of PipeJSONLogs concurrently without
+// any coordination as long as each is the only reader of `r`.
+func PipeJSONLogs(ctx context.Context, commandID string, r io.Reader) {
+	reader := bufio.NewReaderSize(r, stdErrBufferSize)
+	// continuation indicates the previous line was a prefix
+	continuation := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			if !errors.Is(ctx.Err(), context.Canceled) {
+				sink.Debug("context closed", "error", ctx.Err())
+			}
+			return
+		default:
+		}
+		line, isPrefix, err := reader.ReadLine()
+		switch {
+		case err == io.EOF:
+			return
+		case err != nil:
+			sink.Error("reading JSON logs", "error", err)
+			return
+		}
+
+		// The line was longer than our max token size, so it's likely
+		// incomplete and won't unmarshal.
+		if isPrefix || continuation {
+			sink.Error("log line larger than max log line size", "prefix", string(line))
+			continuation = isPrefix
+			continue
+		}
+
+		entry, err := parseJSON(line)
+		if err != nil {
+			sink.Error("parsing JSON logs", "input", line, "error", err)
+			return
+		}
+		out := flattenKVPairs(entry.KVPairs)
+
+		l := newCLILogger(ctx, commandID)
+		if entry.Module != "" {
+			l = l.Named(entry.Module)
+		}
+
+		out = append(out, "timestamp", entry.Timestamp.Format(hclog.TimeFormat))
+		switch hclog.LevelFromString(entry.Level) {
+		case hclog.Trace:
+			l.Trace(entry.Message, out...)
+		case hclog.Debug:
+			l.Debug(entry.Message, out...)
+		case hclog.Info:
+			l.Info(entry.Message, out...)
+		case hclog.Warn:
+			l.Warn(entry.Message, out...)
+		case hclog.Error:
+			l.Error(entry.Message, out...)
+		default:
+			// if there was no log level, it's likely this is unexpected
+			// json from something other than hclog, and we should output
+			// it verbatim.
+			sink.Error("parsing JSON logs", "input", string(line), "error", errors.New("no log level"))
+		}
+	}
+}
+
+// logEntry is the JSON payload that gets written by go-hclog.
+type logEntry struct {
+	Message   string        `json:"@message"`
+	Level     string        `json:"@level"`
+	Timestamp time.Time     `json:"@timestamp"`
+	Module    string        `json:"@module"`
+	KVPairs   []*logEntryKV `json:"kv_pairs"`
+}
+
+// logEntryKV is a key value pair within the go-hclog JSON payload.
+type logEntryKV struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
+// flattenKVPairs is used to flatten KVPair slice into []interface{}
+// for hclog consumption.
+func flattenKVPairs(kvs []*logEntryKV) []interface{} {
+	var result []interface{}
+	for _, kv := range kvs {
+		result = append(result, kv.Key)
+		result = append(result, kv.Value)
+	}
+
+	return result
+}
+
+// parseJSON handles parsing JSON output
+func parseJSON(input []byte) (*logEntry, error) {
+	var raw map[string]interface{}
+	entry := &logEntry{}
+
+	err := json.Unmarshal(input, &raw)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse hclog-specific objects
+	if v, ok := raw["@message"]; ok {
+		entry.Message = v.(string)
+		delete(raw, "@message")
+	}
+
+	if v, ok := raw["@level"]; ok {
+		entry.Level = v.(string)
+		delete(raw, "@level")
+	}
+
+	if v, ok := raw["@timestamp"]; ok {
+		t, err := time.Parse("2006-01-02T15:04:05.000000Z07:00", v.(string))
+		if err != nil {
+			return nil, err
+		}
+		entry.Timestamp = t
+		delete(raw, "@timestamp")
+	}
+
+	if v, ok := raw["@module"]; ok {
+		entry.Module = v.(string)
+		delete(raw, "@module")
+	}
+
+	// Parse dynamic KV args from the hclog payload.
+	for k, v := range raw {
+		entry.KVPairs = append(entry.KVPairs, &logEntryKV{
+			Key:   k,
+			Value: v,
+		})
+	}
+
+	return entry, nil
+}

--- a/tfsdklog/sink_json_test.go
+++ b/tfsdklog/sink_json_test.go
@@ -1,0 +1,105 @@
+package tfsdklog
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseJSON(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       string
+		expected    *logEntry
+		expectedErr error
+	}
+
+	tests := map[string]testCase{
+		"basic": {
+			input: `{"@level":"DEBUG", "@message": "this is a test", "@module": "test", "@timestamp": "2021-09-15T03:07:23.123456Z"}`,
+			expected: &logEntry{
+				Message:   "this is a test",
+				Level:     "DEBUG",
+				Timestamp: time.Date(2021, time.September, 15, 3, 7, 23, 123456000, time.UTC),
+				Module:    "test",
+			},
+		},
+		"kv-pair": {
+			input: `{"@level":"DEBUG", "@message": "this is a test", "@module": "test", "@timestamp": "2021-09-15T03:07:23.123456Z", "kv-pair-1": ["testing", 123]}`,
+			expected: &logEntry{
+				Message:   "this is a test",
+				Level:     "DEBUG",
+				Timestamp: time.Date(2021, time.September, 15, 3, 7, 23, 123456000, time.UTC),
+				Module:    "test",
+				KVPairs: []*logEntryKV{
+					{
+						Key:   "kv-pair-1",
+						Value: []interface{}{"testing", float64(123)},
+					},
+				},
+			},
+		},
+		"kv-pairs": {
+			input: `{"@level":"DEBUG", "@message": "this is a test", "@module": "test", "@timestamp": "2021-09-15T03:07:23.123456Z", "kv-pair-1": ["testing", 123], "kv-pair-2": "foo", "kv-pair-3": 123, "kv-pair-4": {"hello": "world"}}`,
+			expected: &logEntry{
+				Message:   "this is a test",
+				Level:     "DEBUG",
+				Timestamp: time.Date(2021, time.September, 15, 3, 7, 23, 123456000, time.UTC),
+				Module:    "test",
+				KVPairs: []*logEntryKV{
+					{
+						Key:   "kv-pair-1",
+						Value: []interface{}{"testing", float64(123)},
+					},
+					{
+						Key:   "kv-pair-2",
+						Value: "foo",
+					},
+					{
+						Key:   "kv-pair-3",
+						Value: float64(123),
+					},
+					{
+						Key: "kv-pair-4",
+						Value: map[string]interface{}{
+							"hello": "world",
+						},
+					},
+				},
+			},
+		},
+		"unterminated-json": {
+			input:       `{"@level":`,
+			expectedErr: fmt.Errorf("unexpected end of JSON input"),
+		},
+	}
+
+	for name, tc := range tests {
+		name, tc := name, tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseJSON([]byte(tc.input))
+
+			if err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() {
+				t.Fatalf("expected error to be %v, got %v", tc.expectedErr, err)
+			} else if err == nil && tc.expectedErr != nil {
+				t.Fatalf("expected error to be %v, didn't get an error", tc.expectedErr)
+			} else if err != nil && tc.expectedErr == nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Fatalf("unexpected diff (-wanted, +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Starting to address #6. This is just the start of the work, but it gives
us something to build on.

Basically, what we're trying to do is build log sink functionality into
terraform-plugin-log. Normally, Terraform acts as a log sink, gathering
up logs from core and from all the plugins, filtering them
appropriately, and combining them into a single log output stream, and
deciding where to send that stream. However, when running acceptance
tests, the plugin is actually the longest-running process, and so this
model breaks down. Instead, we need to have the plugin act as the sink,
gathering the logs from core and the plugin and other plugins, combining
them into a single stream, filtering the stream, and deciding where to
output the stream.

Rather than implement this functionality multiple times in different
SDKs, it makes more sense to add it to the tfsdklog package and just
call it from the test frameworks.

There are a few parts to this. First, we need a new sink logger that all
other loggers are derived from. It should read environment variables to
determine what level of output is desired, what format of output is
desired, and where to send that output. Second, we should make all our
loggers be sub-loggers of that sink when the sink is set. Third, we
should make sure our sub-loggers can only log at levels equal to or
higher than the level of this new sink logger when it's set. And
finally, we should provide functionality to process hclog JSON output
(like from terraform when TF_LOG=json) and route it through this sink
logger, so we can combine the log output of the CLI and other providers
with the log output native to the process.

This commit falls short in a few places:

* sub-loggers aren't limited to equal-or-higher levels from the sink
  logger yet.
* none of this has been tested, even manually. It builds?
* we need to make the tflog package sink-aware, just like the tfsdklog
  package. This likely involves moving the sink functionality into an
  internal package.
* we need to check that all the environment variables we need to be
  honoring are getting honored for the provider under test, the CLI, and
  the providers the CLI launches.