### PR TITLE
Don't log about invalid log level when TF_LOG isn't set.

### DIFF
--- a/tfsdklog/sink.go
+++ b/tfsdklog/sink.go
@@ -81,8 +81,7 @@ func newSink() hclog.Logger {
 	envLevel := strings.ToUpper(os.Getenv(envLog))
 	if envLevel == "" {
 		logLevel = hclog.Off
-	}
-	if envLevel == "JSON" {
+	} else if envLevel == "JSON" {
 		logLevel = hclog.Trace
 		json = true
 	} else if isValidLogLevel(envLevel) {


### PR DESCRIPTION
When `TF_LOG` isn't set, the sink was erroneously logging about an invalid log level. This corrects that.