### PR TITLE
.circleci: Replace deprecated circleci/golang images with cimg/go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,74 +4,18 @@ commands:
   get_dependencies:
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
-      - run: go get -v -d ./...
-      - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
+      - run: go mod download
 
 jobs:
-  "docker-go115 build":
-    docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
-    steps:
-      - get_dependencies
-      - run: go build ./...
-  "docker-go115 test":
-    docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
-        environment:
-          TF_ACC_TERRAFORM_VERSION: "0.12.26"
-    parameters:
-      test_results:
-        type: string
-        default: /tmp/test-results
-    steps:
-      - get_dependencies
-      - run: mkdir -p << parameters.test_results >>/report
-      - run:
-          command: |
-            gotestsum --junitfile << parameters.test_results >>/report/gotestsum-report.xml -- -coverprofile=cover.out ./...
-            go tool cover -html=cover.out -o coverage.html
-            mv coverage.html << parameters.test_results >>
-      - store_artifacts:
-          path: << parameters.test_results >>
-          destination: raw-test-output
-      - store_test_results:
-          path: << parameters.test_results >>
-  "docker-go115 vet":
-    docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
-    steps:
-      - get_dependencies
-      - run: go vet ./...
-  "docker-go115 gofmt":
-    docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
-    steps:
-      - get_dependencies
-      - run: ./scripts/gofmtcheck.sh
-  "docker-go115 release":
-    docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
-    steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "e8:ed:73:09:72:67:89:18:ee:6a:31:b1:61:33:6d:90"
-      - get_dependencies
-      - run: ./scripts/release/release.sh
   "docker-go116 build":
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
+      - image: docker.mirror.hashicorp.services/cimg/go:1.16
     steps:
       - get_dependencies
       - run: go build ./...
   "docker-go116 test":
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
+      - image: docker.mirror.hashicorp.services/cimg/go:1.16
         environment:
           TF_ACC_TERRAFORM_VERSION: "0.12.26"
     parameters:
@@ -93,13 +37,62 @@ jobs:
           path: << parameters.test_results >>
   "docker-go116 vet":
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
+      - image: docker.mirror.hashicorp.services/cimg/go:1.16
     steps:
       - get_dependencies
       - run: go vet ./...
   "docker-go116 gofmt":
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
+      - image: docker.mirror.hashicorp.services/cimg/go:1.16
+    steps:
+      - get_dependencies
+      - run: ./scripts/gofmtcheck.sh
+  "docker-go116 release":
+    docker:
+      - image: docker.mirror.hashicorp.services/cimg/go:1.16
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "e8:ed:73:09:72:67:89:18:ee:6a:31:b1:61:33:6d:90"
+      - get_dependencies
+      - run: ./scripts/release/release.sh
+  "docker-go117 build":
+    docker:
+      - image: docker.mirror.hashicorp.services/cimg/go:1.17
+    steps:
+      - get_dependencies
+      - run: go build ./...
+  "docker-go117 test":
+    docker:
+      - image: docker.mirror.hashicorp.services/cimg/go:1.17
+        environment:
+          TF_ACC_TERRAFORM_VERSION: "0.12.26"
+    parameters:
+      test_results:
+        type: string
+        default: /tmp/test-results
+    steps:
+      - get_dependencies
+      - run: mkdir -p << parameters.test_results >>/report
+      - run:
+          command: |
+            gotestsum --junitfile << parameters.test_results >>/report/gotestsum-report.xml -- -coverprofile=cover.out ./...
+            go tool cover -html=cover.out -o coverage.html
+            mv coverage.html << parameters.test_results >>
+      - store_artifacts:
+          path: << parameters.test_results >>
+          destination: raw-test-output
+      - store_test_results:
+          path: << parameters.test_results >>
+  "docker-go117 vet":
+    docker:
+      - image: docker.mirror.hashicorp.services/cimg/go:1.17
+    steps:
+      - get_dependencies
+      - run: go vet ./...
+  "docker-go117 gofmt":
+    docker:
+      - image: docker.mirror.hashicorp.services/cimg/go:1.17
     steps:
       - get_dependencies
       - run: ./scripts/gofmtcheck.sh
@@ -108,16 +101,6 @@ workflows:
   version: 2
   pr:
     jobs:
-      - "docker-go115 build"
-      - "docker-go115 test":
-          requires:
-            - "docker-go115 build"
-      - "docker-go115 vet":
-          requires:
-            - "docker-go115 build"
-      - "docker-go115 gofmt":
-          requires:
-            - "docker-go115 build"
       - "docker-go116 build"
       - "docker-go116 test":
           requires:
@@ -128,18 +111,18 @@ workflows:
       - "docker-go116 gofmt":
           requires:
             - "docker-go116 build"
+      - "docker-go117 build"
+      - "docker-go117 test":
+          requires:
+            - "docker-go117 build"
+      - "docker-go117 vet":
+          requires:
+            - "docker-go117 build"
+      - "docker-go117 gofmt":
+          requires:
+            - "docker-go117 build"
   release:
     jobs:
-      - "docker-go115 build"
-      - "docker-go115 test":
-          requires:
-            - "docker-go115 build"
-      - "docker-go115 vet":
-          requires:
-            - "docker-go115 build"
-      - "docker-go115 gofmt":
-          requires:
-            - "docker-go115 build"
       - "docker-go116 build"
       - "docker-go116 test":
           requires:
@@ -150,22 +133,32 @@ workflows:
       - "docker-go116 gofmt":
           requires:
             - "docker-go116 build"
+      - "docker-go117 build"
+      - "docker-go117 test":
+          requires:
+            - "docker-go117 build"
+      - "docker-go117 vet":
+          requires:
+            - "docker-go117 build"
+      - "docker-go117 gofmt":
+          requires:
+            - "docker-go117 build"
       - trigger-release:
           filters:
             branches:
               only:
                 - main
           type: approval
-      - "docker-go115 release":
+      - "docker-go116 release":
           filters:
             branches:
               only:
                 - main
           requires:
             - trigger-release
-            - "docker-go115 test"
-            - "docker-go115 vet"
-            - "docker-go115 gofmt"
             - "docker-go116 test"
             - "docker-go116 vet"
             - "docker-go116 gofmt"
+            - "docker-go117 test"
+            - "docker-go117 vet"
+            - "docker-go117 gofmt"


### PR DESCRIPTION
Closes #18 

Also upgrades Go testing from Go 1.16 -> 1.17 and 1.15 -> 1.16 to match our support policies.