### PR TITLE
Don't panic when no logger is setup.

### DIFF
--- a/.changelog/24.txt
+++ b/.changelog/24.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed a panic when logging to a subsystem when logging has not been set up on the context. Should only impact unit tests and other situations where an SDK isn't instantiating the logging context.
+```

--- a/tflog/subsystem.go
+++ b/tflog/subsystem.go
@@ -42,6 +42,11 @@ func NewSubsystem(ctx context.Context, subsystem string, options ...logging.Opti
 func SubsystemWith(ctx context.Context, subsystem, key string, value interface{}) context.Context {
 	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetProviderRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return ctx
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetProviderSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewProviderSubsystemLoggerWarning)
 	}
@@ -54,6 +59,11 @@ func SubsystemWith(ctx context.Context, subsystem, key string, value interface{}
 func SubsystemTrace(ctx context.Context, subsystem, msg string, args ...interface{}) {
 	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetProviderRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetProviderSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewProviderSubsystemLoggerWarning)
 	}
@@ -66,6 +76,11 @@ func SubsystemTrace(ctx context.Context, subsystem, msg string, args ...interfac
 func SubsystemDebug(ctx context.Context, subsystem, msg string, args ...interface{}) {
 	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetProviderRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetProviderSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewProviderSubsystemLoggerWarning)
 	}
@@ -78,6 +93,11 @@ func SubsystemDebug(ctx context.Context, subsystem, msg string, args ...interfac
 func SubsystemInfo(ctx context.Context, subsystem, msg string, args ...interface{}) {
 	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetProviderRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetProviderSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewProviderSubsystemLoggerWarning)
 	}
@@ -90,6 +110,11 @@ func SubsystemInfo(ctx context.Context, subsystem, msg string, args ...interface
 func SubsystemWarn(ctx context.Context, subsystem, msg string, args ...interface{}) {
 	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetProviderRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetProviderSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewProviderSubsystemLoggerWarning)
 	}
@@ -102,6 +127,11 @@ func SubsystemWarn(ctx context.Context, subsystem, msg string, args ...interface
 func SubsystemError(ctx context.Context, subsystem, msg string, args ...interface{}) {
 	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetProviderRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetProviderSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewProviderSubsystemLoggerWarning)
 	}

--- a/tfsdklog/subsystem.go
+++ b/tfsdklog/subsystem.go
@@ -42,6 +42,11 @@ func NewSubsystem(ctx context.Context, subsystem string, options ...logging.Opti
 func SubsystemWith(ctx context.Context, subsystem, key string, value interface{}) context.Context {
 	logger := logging.GetSDKSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetSDKRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return ctx
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetSDKSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewSDKSubsystemLoggerWarning)
 	}
@@ -54,6 +59,11 @@ func SubsystemWith(ctx context.Context, subsystem, key string, value interface{}
 func SubsystemTrace(ctx context.Context, subsystem, msg string, args ...interface{}) {
 	logger := logging.GetSDKSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetSDKRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetSDKSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewSDKSubsystemLoggerWarning)
 	}
@@ -66,6 +76,11 @@ func SubsystemTrace(ctx context.Context, subsystem, msg string, args ...interfac
 func SubsystemDebug(ctx context.Context, subsystem, msg string, args ...interface{}) {
 	logger := logging.GetSDKSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetSDKRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetSDKSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewSDKSubsystemLoggerWarning)
 	}
@@ -78,6 +93,11 @@ func SubsystemDebug(ctx context.Context, subsystem, msg string, args ...interfac
 func SubsystemInfo(ctx context.Context, subsystem, msg string, args ...interface{}) {
 	logger := logging.GetSDKSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetSDKRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetSDKSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewSDKSubsystemLoggerWarning)
 	}
@@ -90,6 +110,11 @@ func SubsystemInfo(ctx context.Context, subsystem, msg string, args ...interface
 func SubsystemWarn(ctx context.Context, subsystem, msg string, args ...interface{}) {
 	logger := logging.GetSDKSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetSDKRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetSDKSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewSDKSubsystemLoggerWarning)
 	}
@@ -102,6 +127,11 @@ func SubsystemWarn(ctx context.Context, subsystem, msg string, args ...interface
 func SubsystemError(ctx context.Context, subsystem, msg string, args ...interface{}) {
 	logger := logging.GetSDKSubsystemLogger(ctx, subsystem)
 	if logger == nil {
+		if logging.GetSDKRootLogger(ctx) == nil {
+			// logging isn't set up, nothing we can do, just silently fail
+			// this should basically never happen in production
+			return
+		}
 		// create a new logger if one doesn't exist
 		logger = logging.GetSDKSubsystemLogger(NewSubsystem(ctx, subsystem), subsystem).With("new_logger_warning", logging.NewSDKSubsystemLoggerWarning)
 	}


### PR DESCRIPTION
Don't panic, instead just silently swallow logs, when logging isn't set
up. This mostly will happen in situations like unit tests where contexts
are being created directly, instead of by an SDK layer. Rather than
panicking in those situations or intermingling logging output with test
output, it's reasonable to just not write logs at all, which is usually
what people would want. For people that don't want that, they can call
the code to set up the loggers themselves.