### PR TITLE
tflog+tfsdklog: Add root and subsystem unit testing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - ineffassign
     - makezero
     - nilerr
-    - paralleltest
+    # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14
     - predeclared
     - staticcheck
     # - tenv # TODO: Enable when upgrading Go 1.16 to 1.17

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/terraform-plugin-log
 go 1.16
 
 require (
+	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/go-hclog v1.1.0
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/stretchr/testify v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/hashicorp/go-hclog v1.1.0 h1:QsGcniKx5/LuX2eYoeL+Np3UKYPNaN7YKpTh29h8rbw=
 github.com/hashicorp/go-hclog v1.1.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
@@ -21,3 +23,5 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/loggertest/json_decode.go
+++ b/internal/loggertest/json_decode.go
@@ -1,0 +1,30 @@
+package loggertest
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+func MultilineJSONDecode(data io.Reader) ([]map[string]interface{}, error) {
+	var result []map[string]interface{}
+	var entry map[string]interface{}
+
+	dec := json.NewDecoder(data)
+
+	for {
+		err := dec.Decode(&entry)
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return result, fmt.Errorf("unable to decode JSON: %s", err)
+		}
+
+		result = append(result, entry)
+	}
+
+	return result, nil
+}

--- a/internal/loggertest/provider.go
+++ b/internal/loggertest/provider.go
@@ -1,0 +1,22 @@
+package loggertest
+
+import (
+	"context"
+	"io"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-log/internal/logging"
+)
+
+func ProviderRoot(ctx context.Context, output io.Writer) context.Context {
+	loggerOptions := &hclog.LoggerOptions{
+		DisableTime: true,
+		JSONFormat:  true,
+		Level:       hclog.Trace,
+		Output:      output,
+	}
+
+	ctx = logging.SetProviderRootLogger(ctx, hclog.New(loggerOptions))
+
+	return ctx
+}

--- a/internal/loggertest/sdk.go
+++ b/internal/loggertest/sdk.go
@@ -1,0 +1,22 @@
+package loggertest
+
+import (
+	"context"
+	"io"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-log/internal/logging"
+)
+
+func SDKRoot(ctx context.Context, output io.Writer) context.Context {
+	loggerOptions := &hclog.LoggerOptions{
+		DisableTime: true,
+		JSONFormat:  true,
+		Level:       hclog.Trace,
+		Output:      output,
+	}
+
+	ctx = logging.SetSDKRootLogger(ctx, hclog.New(loggerOptions))
+
+	return ctx
+}

--- a/tflog/provider_test.go
+++ b/tflog/provider_test.go
@@ -1,0 +1,473 @@
+package tflog_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-log/internal/loggertest"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+func TestWith(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		key            string
+		value          interface{}
+		logMessage     string
+		logArgs        []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-log-pairs": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":        hclog.Trace.String(),
+					"@message":      "test message",
+					"test-with-key": "test-with-value",
+				},
+			},
+		},
+		"mismatched-log-pair": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			logArgs:    []interface{}{"unpaired-test-log-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					"test-with-key":  "test-with-value",
+					hclog.MissingKey: "unpaired-test-log-key",
+				},
+			},
+		},
+		"mismatched-with-pair": {
+			key:        "unpaired-test-with-key",
+			logMessage: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":                 hclog.Trace.String(),
+					"@message":               "test message",
+					"unpaired-test-with-key": nil,
+				},
+			},
+		},
+		"with-and-log-pairs": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			logArgs: []interface{}{
+				"test-log-key-1", "test-log-value-1",
+				"test-log-key-2", "test-log-value-2",
+				"test-log-key-3", "test-log-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					"test-log-key-1": "test-log-value-1",
+					"test-log-key-2": "test-log-value-2",
+					"test-log-key-3": "test-log-value-3",
+					"test-with-key":  "test-with-value",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.With(ctx, testCase.key, testCase.value)
+
+			tflog.Trace(ctx, testCase.logMessage, testCase.logArgs...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestTrace(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Trace.String(),
+					"@message": "test message",
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Trace.String(),
+					"@message":   "test message",
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+
+			tflog.Trace(ctx, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestDebug(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Debug.String(),
+					"@message": "test message",
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Debug.String(),
+					"@message":       "test message",
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Debug.String(),
+					"@message":   "test message",
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+
+			tflog.Debug(ctx, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestInfo(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Info.String(),
+					"@message": "test message",
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Info.String(),
+					"@message":       "test message",
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Info.String(),
+					"@message":   "test message",
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+
+			tflog.Info(ctx, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestWarn(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Warn.String(),
+					"@message": "test message",
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Warn.String(),
+					"@message":       "test message",
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Warn.String(),
+					"@message":   "test message",
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+
+			tflog.Warn(ctx, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Error.String(),
+					"@message": "test message",
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Error.String(),
+					"@message":       "test message",
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Error.String(),
+					"@message":   "test message",
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+
+			tflog.Error(ctx, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}

--- a/tflog/subsystem_test.go
+++ b/tflog/subsystem_test.go
@@ -1,0 +1,500 @@
+package tflog_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-log/internal/loggertest"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const testSubsystem = "test_subsystem"
+
+func TestSubsystemWith(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		key            string
+		value          interface{}
+		logMessage     string
+		logArgs        []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-log-pairs": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":        hclog.Trace.String(),
+					"@message":      "test message",
+					"@module":       testSubsystem,
+					"test-with-key": "test-with-value",
+				},
+			},
+		},
+		"mismatched-log-pair": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			logArgs:    []interface{}{"unpaired-test-log-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					"test-with-key":  "test-with-value",
+					hclog.MissingKey: "unpaired-test-log-key",
+				},
+			},
+		},
+		"mismatched-with-pair": {
+			key:        "unpaired-test-with-key",
+			logMessage: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":                 hclog.Trace.String(),
+					"@message":               "test message",
+					"@module":                testSubsystem,
+					"unpaired-test-with-key": nil,
+				},
+			},
+		},
+		"with-and-log-pairs": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			logArgs: []interface{}{
+				"test-log-key-1", "test-log-value-1",
+				"test-log-key-2", "test-log-value-2",
+				"test-log-key-3", "test-log-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					"test-log-key-1": "test-log-value-1",
+					"test-log-key-2": "test-log-value-2",
+					"test-log-key-3": "test-log-value-3",
+					"test-with-key":  "test-with-value",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem)
+			ctx = tflog.SubsystemWith(ctx, testSubsystem, testCase.key, testCase.value)
+
+			tflog.SubsystemTrace(ctx, testSubsystem, testCase.logMessage, testCase.logArgs...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsystemTrace(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Trace.String(),
+					"@message": "test message",
+					"@module":  testSubsystem,
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Trace.String(),
+					"@message":   "test message",
+					"@module":    testSubsystem,
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem)
+
+			tflog.SubsystemTrace(ctx, testSubsystem, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsystemDebug(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Debug.String(),
+					"@message": "test message",
+					"@module":  testSubsystem,
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Debug.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Debug.String(),
+					"@message":   "test message",
+					"@module":    testSubsystem,
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem)
+
+			tflog.SubsystemDebug(ctx, testSubsystem, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsystemInfo(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Info.String(),
+					"@message": "test message",
+					"@module":  testSubsystem,
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Info.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Info.String(),
+					"@message":   "test message",
+					"@module":    testSubsystem,
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem)
+
+			tflog.SubsystemInfo(ctx, testSubsystem, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsystemWarn(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Warn.String(),
+					"@message": "test message",
+					"@module":  testSubsystem,
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Warn.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Warn.String(),
+					"@message":   "test message",
+					"@module":    testSubsystem,
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem)
+
+			tflog.SubsystemWarn(ctx, testSubsystem, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsystemError(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Error.String(),
+					"@message": "test message",
+					"@module":  testSubsystem,
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Error.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Error.String(),
+					"@message":   "test message",
+					"@module":    testSubsystem,
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem)
+
+			tflog.SubsystemError(ctx, testSubsystem, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}

--- a/tfsdklog/sdk_test.go
+++ b/tfsdklog/sdk_test.go
@@ -1,0 +1,473 @@
+package tfsdklog_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-log/internal/loggertest"
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+func TestWith(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		key            string
+		value          interface{}
+		logMessage     string
+		logArgs        []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-log-pairs": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":        hclog.Trace.String(),
+					"@message":      "test message",
+					"test-with-key": "test-with-value",
+				},
+			},
+		},
+		"mismatched-log-pair": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			logArgs:    []interface{}{"unpaired-test-log-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					"test-with-key":  "test-with-value",
+					hclog.MissingKey: "unpaired-test-log-key",
+				},
+			},
+		},
+		"mismatched-with-pair": {
+			key:        "unpaired-test-with-key",
+			logMessage: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":                 hclog.Trace.String(),
+					"@message":               "test message",
+					"unpaired-test-with-key": nil,
+				},
+			},
+		},
+		"with-and-log-pairs": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			logArgs: []interface{}{
+				"test-log-key-1", "test-log-value-1",
+				"test-log-key-2", "test-log-value-2",
+				"test-log-key-3", "test-log-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					"test-log-key-1": "test-log-value-1",
+					"test-log-key-2": "test-log-value-2",
+					"test-log-key-3": "test-log-value-3",
+					"test-with-key":  "test-with-value",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.With(ctx, testCase.key, testCase.value)
+
+			tfsdklog.Trace(ctx, testCase.logMessage, testCase.logArgs...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestTrace(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Trace.String(),
+					"@message": "test message",
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Trace.String(),
+					"@message":   "test message",
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+
+			tfsdklog.Trace(ctx, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestDebug(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Debug.String(),
+					"@message": "test message",
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Debug.String(),
+					"@message":       "test message",
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Debug.String(),
+					"@message":   "test message",
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+
+			tfsdklog.Debug(ctx, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestInfo(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Info.String(),
+					"@message": "test message",
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Info.String(),
+					"@message":       "test message",
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Info.String(),
+					"@message":   "test message",
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+
+			tfsdklog.Info(ctx, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestWarn(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Warn.String(),
+					"@message": "test message",
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Warn.String(),
+					"@message":       "test message",
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Warn.String(),
+					"@message":   "test message",
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+
+			tfsdklog.Warn(ctx, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Error.String(),
+					"@message": "test message",
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Error.String(),
+					"@message":       "test message",
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Error.String(),
+					"@message":   "test message",
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+
+			tfsdklog.Error(ctx, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}

--- a/tfsdklog/subsystem_test.go
+++ b/tfsdklog/subsystem_test.go
@@ -1,0 +1,500 @@
+package tfsdklog_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-log/internal/loggertest"
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+const testSubsystem = "test_subsystem"
+
+func TestSubsystemWith(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		key            string
+		value          interface{}
+		logMessage     string
+		logArgs        []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-log-pairs": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":        hclog.Trace.String(),
+					"@message":      "test message",
+					"@module":       testSubsystem,
+					"test-with-key": "test-with-value",
+				},
+			},
+		},
+		"mismatched-log-pair": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			logArgs:    []interface{}{"unpaired-test-log-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					"test-with-key":  "test-with-value",
+					hclog.MissingKey: "unpaired-test-log-key",
+				},
+			},
+		},
+		"mismatched-with-pair": {
+			key:        "unpaired-test-with-key",
+			logMessage: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":                 hclog.Trace.String(),
+					"@message":               "test message",
+					"@module":                testSubsystem,
+					"unpaired-test-with-key": nil,
+				},
+			},
+		},
+		"with-and-log-pairs": {
+			key:        "test-with-key",
+			value:      "test-with-value",
+			logMessage: "test message",
+			logArgs: []interface{}{
+				"test-log-key-1", "test-log-value-1",
+				"test-log-key-2", "test-log-value-2",
+				"test-log-key-3", "test-log-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					"test-log-key-1": "test-log-value-1",
+					"test-log-key-2": "test-log-value-2",
+					"test-log-key-3": "test-log-value-3",
+					"test-with-key":  "test-with-value",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem)
+			ctx = tfsdklog.SubsystemWith(ctx, testSubsystem, testCase.key, testCase.value)
+
+			tfsdklog.SubsystemTrace(ctx, testSubsystem, testCase.logMessage, testCase.logArgs...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsystemTrace(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Trace.String(),
+					"@message": "test message",
+					"@module":  testSubsystem,
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Trace.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Trace.String(),
+					"@message":   "test message",
+					"@module":    testSubsystem,
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem)
+
+			tfsdklog.SubsystemTrace(ctx, testSubsystem, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsystemDebug(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Debug.String(),
+					"@message": "test message",
+					"@module":  testSubsystem,
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Debug.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Debug.String(),
+					"@message":   "test message",
+					"@module":    testSubsystem,
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem)
+
+			tfsdklog.SubsystemDebug(ctx, testSubsystem, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsystemInfo(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Info.String(),
+					"@message": "test message",
+					"@module":  testSubsystem,
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Info.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Info.String(),
+					"@message":   "test message",
+					"@module":    testSubsystem,
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem)
+
+			tfsdklog.SubsystemInfo(ctx, testSubsystem, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsystemWarn(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Warn.String(),
+					"@message": "test message",
+					"@module":  testSubsystem,
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Warn.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Warn.String(),
+					"@message":   "test message",
+					"@module":    testSubsystem,
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem)
+
+			tfsdklog.SubsystemWarn(ctx, testSubsystem, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSubsystemError(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		message        string
+		args           []interface{}
+		expectedOutput []map[string]interface{}
+	}{
+		"no-pairs": {
+			message: "test message",
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":   hclog.Error.String(),
+					"@message": "test message",
+					"@module":  testSubsystem,
+				},
+			},
+		},
+		"mismatched-pair": {
+			message: "test message",
+			args:    []interface{}{"unpaired-test-key"},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":         hclog.Error.String(),
+					"@message":       "test message",
+					"@module":        testSubsystem,
+					hclog.MissingKey: "unpaired-test-key",
+				},
+			},
+		},
+		"pairs": {
+			message: "test message",
+			args: []interface{}{
+				"test-key-1", "test-value-1",
+				"test-key-2", "test-value-2",
+				"test-key-3", "test-value-3",
+			},
+			expectedOutput: []map[string]interface{}{
+				{
+					"@level":     hclog.Error.String(),
+					"@message":   "test message",
+					"@module":    testSubsystem,
+					"test-key-1": "test-value-1",
+					"test-key-2": "test-value-2",
+					"test-key-3": "test-value-3",
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem)
+
+			tfsdklog.SubsystemError(ctx, testSubsystem, testCase.message, testCase.args...)
+
+			got, err := loggertest.MultilineJSONDecode(&outputBuffer)
+
+			if err != nil {
+				t.Fatalf("unable to read multiple line JSON: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
+				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-log/issues/31

Backfill unit testing for the following functions:

- `With()` / `SubsystemWith()`
- `Trace()`/ `SubsystemTrace()`
- `Debug()`/ `SubsystemDebug()`
- `Info()`/ `SubsystemInfo()`
- `Warn()`/ `SubsystemWarn()`
- `Error()`/ `SubsystemError()`

In preparation for potential updates to the function signatures to prevent `EXTRA_VALUE_AT_END` in log entries.