### PR TITLE
ci: added `forcetypeassert`, `misspell`, and `paralleltest` lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters:
     - makezero
     - misspell
     - nilerr
-    # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14
+    - paralleltest
     - predeclared
     - staticcheck
     - tenv

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,14 +5,15 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - durationcheck
     - errcheck
     - exportloopref
+    - forcetypeassert
     - gofmt
     - gosimple
     - ineffassign
     - makezero
+    - misspell
     - nilerr
     # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14
     - predeclared
@@ -20,5 +21,5 @@ linters:
     - tenv
     - unconvert
     - unparam
-    - varcheck
+    - unused
     - vet

--- a/internal/hclogutils/args_test.go
+++ b/internal/hclogutils/args_test.go
@@ -151,6 +151,7 @@ func TestFieldMapsToArgs(t *testing.T) {
 			gotValues := make(map[string]interface{}, len(got)/2)
 
 			for i := 0; i < len(got); i += 2 {
+				//nolint:forcetypeassert // Not needed in test of log mapping
 				k, v := got[i].(string), got[i+1]
 				gotKeys = append(gotKeys, k)
 				gotValues[k] = v

--- a/internal/logging/provider.go
+++ b/internal/logging/provider.go
@@ -13,7 +13,12 @@ func GetProviderRootLogger(ctx context.Context) hclog.Logger {
 	if logger == nil {
 		return nil
 	}
-	return logger.(hclog.Logger)
+
+	hclogger, ok := logger.(hclog.Logger)
+	if !ok {
+		return nil
+	}
+	return hclogger
 }
 
 // GetProviderRootLoggerOptions returns the root logger options used for
@@ -64,7 +69,13 @@ func GetProviderSubsystemLogger(ctx context.Context, subsystem string) hclog.Log
 	if logger == nil {
 		return nil
 	}
-	return logger.(hclog.Logger)
+
+	hclogger, ok := logger.(hclog.Logger)
+	if !ok {
+		return nil
+	}
+
+	return hclogger
 }
 
 // SetProviderSubsystemLogger sets `logger` as the logger for the named

--- a/internal/logging/sdk.go
+++ b/internal/logging/sdk.go
@@ -13,7 +13,13 @@ func GetSDKRootLogger(ctx context.Context) hclog.Logger {
 	if logger == nil {
 		return nil
 	}
-	return logger.(hclog.Logger)
+
+	hclogger, ok := logger.(hclog.Logger)
+	if !ok {
+		return nil
+	}
+
+	return hclogger
 }
 
 // GetSDKRootLoggerOptions returns the root logger options used for
@@ -80,7 +86,13 @@ func GetSDKSubsystemLogger(ctx context.Context, subsystem string) hclog.Logger {
 	if logger == nil {
 		return nil
 	}
-	return logger.(hclog.Logger)
+
+	hclogger, ok := logger.(hclog.Logger)
+	if !ok {
+		return nil
+	}
+
+	return hclogger
 }
 
 // SetSDKSubsystemLogger sets `logger` as the logger for the named subsystem in

--- a/internal/logging/sink.go
+++ b/internal/logging/sink.go
@@ -13,7 +13,13 @@ func GetSink(ctx context.Context) hclog.Logger {
 	if logger == nil {
 		return nil
 	}
-	return logger.(hclog.Logger)
+
+	hclogger, ok := logger.(hclog.Logger)
+	if !ok {
+		return nil
+	}
+
+	return hclogger
 }
 
 // GetSinkOptions returns the root logger options used for

--- a/tflog/provider_test.go
+++ b/tflog/provider_test.go
@@ -566,6 +566,8 @@ func TestError(t *testing.T) {
 const testLogMsg = "System FOO has caused error BAR because of incorrectly configured BAZ"
 
 func TestOmitLogWithFieldKeys(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -650,6 +652,8 @@ func TestOmitLogWithFieldKeys(t *testing.T) {
 }
 
 func TestOmitLogWithMessageRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -734,6 +738,8 @@ func TestOmitLogWithMessageRegexes(t *testing.T) {
 }
 
 func TestOmitLogWithMessageStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -818,6 +824,8 @@ func TestOmitLogWithMessageStrings(t *testing.T) {
 }
 
 func TestMaskFieldValuesWithFieldKeys(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -910,6 +918,8 @@ func TestMaskFieldValuesWithFieldKeys(t *testing.T) {
 }
 
 func TestMaskAllFieldValuesRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1002,6 +1012,8 @@ func TestMaskAllFieldValuesRegexes(t *testing.T) {
 }
 
 func TestMaskAllFieldValuesStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1094,6 +1106,8 @@ func TestMaskAllFieldValuesStrings(t *testing.T) {
 }
 
 func TestMaskMessageRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -1186,6 +1200,8 @@ func TestMaskMessageRegexes(t *testing.T) {
 }
 
 func TestMaskMessageStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -1278,6 +1294,8 @@ func TestMaskMessageStrings(t *testing.T) {
 }
 
 func TestMaskLogRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1370,6 +1388,8 @@ func TestMaskLogRegexes(t *testing.T) {
 }
 
 func TestMaskLogStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}

--- a/tflog/subsystem_test.go
+++ b/tflog/subsystem_test.go
@@ -575,6 +575,8 @@ func TestSubsystemError(t *testing.T) {
 }
 
 func TestSubsystemOmitLogWithFieldKeys(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -660,6 +662,8 @@ func TestSubsystemOmitLogWithFieldKeys(t *testing.T) {
 }
 
 func TestSubsystemOmitLogWithMessageRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -745,6 +749,8 @@ func TestSubsystemOmitLogWithMessageRegexes(t *testing.T) {
 }
 
 func TestSubsystemOmitLogWithMessageStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -830,6 +836,8 @@ func TestSubsystemOmitLogWithMessageStrings(t *testing.T) {
 }
 
 func TestSubsystemMaskFieldValuesWithFieldKeys(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -923,6 +931,8 @@ func TestSubsystemMaskFieldValuesWithFieldKeys(t *testing.T) {
 }
 
 func TestSubsystemMaskAllFieldValuesRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1016,6 +1026,8 @@ func TestSubsystemMaskAllFieldValuesRegexes(t *testing.T) {
 }
 
 func TestSubsystemMaskAllFieldValuesStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1109,6 +1121,8 @@ func TestSubsystemMaskAllFieldValuesStrings(t *testing.T) {
 }
 
 func TestSubsystemMaskMessageRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -1202,6 +1216,8 @@ func TestSubsystemMaskMessageRegexes(t *testing.T) {
 }
 
 func TestSubsystemMaskMessageStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -1295,6 +1311,8 @@ func TestSubsystemMaskMessageStrings(t *testing.T) {
 }
 
 func TestSubsystemMaskLogRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1388,6 +1406,8 @@ func TestSubsystemMaskLogRegexes(t *testing.T) {
 }
 
 func TestSubsystemMaskLogStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}

--- a/tfsdklog/sdk_test.go
+++ b/tfsdklog/sdk_test.go
@@ -566,6 +566,8 @@ func TestError(t *testing.T) {
 const testLogMsg = "System FOO has caused error BAR because of incorrectly configured BAZ"
 
 func TestOmitLogWithFieldKeys(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -650,6 +652,8 @@ func TestOmitLogWithFieldKeys(t *testing.T) {
 }
 
 func TestOmitLogWithMessageRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -734,6 +738,8 @@ func TestOmitLogWithMessageRegexes(t *testing.T) {
 }
 
 func TestOmitLogWithMessageStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -818,6 +824,8 @@ func TestOmitLogWithMessageStrings(t *testing.T) {
 }
 
 func TestMaskFieldValuesWithFieldKeys(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -910,6 +918,8 @@ func TestMaskFieldValuesWithFieldKeys(t *testing.T) {
 }
 
 func TestMaskAllFieldValuesRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1002,6 +1012,8 @@ func TestMaskAllFieldValuesRegexes(t *testing.T) {
 }
 
 func TestMaskAllFieldValuesStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1094,6 +1106,8 @@ func TestMaskAllFieldValuesStrings(t *testing.T) {
 }
 
 func TestMaskMessageRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -1186,6 +1200,8 @@ func TestMaskMessageRegexes(t *testing.T) {
 }
 
 func TestMaskMessageStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -1278,6 +1294,8 @@ func TestMaskMessageStrings(t *testing.T) {
 }
 
 func TestMaskLogRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1370,6 +1388,8 @@ func TestMaskLogRegexes(t *testing.T) {
 }
 
 func TestMaskLogStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}

--- a/tfsdklog/subsystem_test.go
+++ b/tfsdklog/subsystem_test.go
@@ -575,6 +575,8 @@ func TestSubsystemError(t *testing.T) {
 }
 
 func TestSubsystemOmitLogWithFieldKeys(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -660,6 +662,8 @@ func TestSubsystemOmitLogWithFieldKeys(t *testing.T) {
 }
 
 func TestSubsystemOmitLogWithMessageRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -745,6 +749,8 @@ func TestSubsystemOmitLogWithMessageRegexes(t *testing.T) {
 }
 
 func TestSubsystemOmitLogWithMessageStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -830,6 +836,8 @@ func TestSubsystemOmitLogWithMessageStrings(t *testing.T) {
 }
 
 func TestSubsystemMaskFieldValuesWithFieldKeys(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -923,6 +931,8 @@ func TestSubsystemMaskFieldValuesWithFieldKeys(t *testing.T) {
 }
 
 func TestSubsystemMaskAllFieldValuesRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1016,6 +1026,8 @@ func TestSubsystemMaskAllFieldValuesRegexes(t *testing.T) {
 }
 
 func TestSubsystemMaskAllFieldValuesStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1109,6 +1121,8 @@ func TestSubsystemMaskAllFieldValuesStrings(t *testing.T) {
 }
 
 func TestSubsystemMaskMessageRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -1202,6 +1216,8 @@ func TestSubsystemMaskMessageRegexes(t *testing.T) {
 }
 
 func TestSubsystemMaskMessageStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg                   string
 		additionalFields      []map[string]interface{}
@@ -1295,6 +1311,8 @@ func TestSubsystemMaskMessageStrings(t *testing.T) {
 }
 
 func TestSubsystemMaskLogRegexes(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}
@@ -1388,6 +1406,8 @@ func TestSubsystemMaskLogRegexes(t *testing.T) {
 }
 
 func TestSubsystemMaskLogStrings(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		msg              string
 		additionalFields []map[string]interface{}


### PR DESCRIPTION
contributes to: 
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/102
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/83
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/126

### Notes
- `deadcode` and `varcheck` linters are deprecated in **golangci-lint** in favor of `unused`
```bash
 $ golangci-lint run
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
```