### PR TITLE
Fix goreleaser deprecated `build` field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 project_name: terraform-plugin-log
-build:
-  skip: true
+builds:
+  - skip: true
 milestones:
   - close: true
 release:


### PR DESCRIPTION
Goreleaser deprecated the `build` field as it was previously not a documented field. Replaced with the equivalent `builds` array per deprecation guide: https://goreleaser.com/deprecations/#build

Failures seen in:
- https://github.com/hashicorp/terraform-plugin-log/pull/138
- https://github.com/hashicorp/terraform-plugin-log/pull/139