### PR TITLE
Add comments for UDR migration

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,5 +1,8 @@
 # Terraform Documentation
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 This directory contains the portions of [the Terraform website][terraform.io] that pertain to the Terraform Plugin Log.
 
 The files in this directory are intended to be used in conjunction with

--- a/website/docs/plugin/log/filtering.mdx
+++ b/website/docs/plugin/log/filtering.mdx
@@ -4,6 +4,9 @@ description: >-
   Omit or mask specific log information from your provider to hide sensitive data.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Filtering Log Output
 
 When providers [write logs](/terraform/plugin/log/writing), there may be sensitive data which should not be present in log messages or structured log fields. The [`tflog` package](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log/tflog) supports masking data or omitting log entries entirely before they are output via the provider root logger or provider-defined subsystem loggers.

--- a/website/docs/plugin/log/index.mdx
+++ b/website/docs/plugin/log/index.mdx
@@ -4,6 +4,9 @@ description: >-
   Enable and filter log output for debugging. Write provider logic to generate helpful logs.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Logging
 
 Terraform CLI, provider SDKs, and provider logic support a rich logging framework for [debugging](/terraform/plugin/debugging) in testing and production.

--- a/website/docs/plugin/log/managing.mdx
+++ b/website/docs/plugin/log/managing.mdx
@@ -4,6 +4,9 @@ description: >-
   Filter log outputs by subsystem and verbosity level. Set the log format and output path.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Managing Log Output
 
 Terraform binary, providers, and provider SDKs can all write logs that provide insight into operations and help you diagnose bugs. You can use environment variables to turn on logging, filter log output, choose the log format, and specify the log output path.

--- a/website/docs/plugin/log/writing.mdx
+++ b/website/docs/plugin/log/writing.mdx
@@ -4,6 +4,9 @@ description: >-
   Write logs from your provider that help users debug issues and understand operations.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+
 # Writing Log Output
 
 Use the [`tflog` package](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log/tflog) to write logs for your provider. SDKs like the `terraform-plugin-framework`, `terraform-plugin-go`, and `terraform-plugin-sdk/v2` set up logging for you, so you only need to write the logs themselves. You can write log output at varying verbosity levels, add fields to logs, and create subsystems to group logs that relate to distinct sections of code (e.g., the API client).


### PR DESCRIPTION
### Description

We are migrating the terraform-plugin-* documentation to a unified HashiCorp product documentation repository. As a result of this migration, the unified repo (web-unified-docs) will be the source of truth.

This PR adds a noticed to all existing MDX files in the original location so folks know where to contribute. We plan on deprecating and removing the files in /website.

This PR will be merged after docs have been migrated