### PR TITLE
Adds log level guard functions

### DIFF
--- a/internal/loggertest/provider.go
+++ b/internal/loggertest/provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-log/internal/logging"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 )
@@ -17,6 +18,18 @@ func ProviderRoot(ctx context.Context, output io.Writer) context.Context {
 		logging.WithoutLocation(),
 		logging.WithoutTimestamp(),
 		logging.WithOutput(output),
+	)
+}
+
+// ProviderRootWithLevel creates a provider root logger at the given level.
+// Use this in tests that need to verify behaviour at a specific log level.
+func ProviderRootWithLevel(ctx context.Context, output io.Writer, level hclog.Level) context.Context {
+	return tfsdklog.NewRootProviderLogger(
+		ctx,
+		logging.WithoutLocation(),
+		logging.WithoutTimestamp(),
+		logging.WithOutput(output),
+		tfsdklog.WithLevel(level),
 	)
 }
 

--- a/internal/loggertest/provider.go
+++ b/internal/loggertest/provider.go
@@ -21,6 +21,18 @@ func ProviderRoot(ctx context.Context, output io.Writer) context.Context {
 	)
 }
 
+// SDKRootWithLevel creates an SDK root logger at the given level.
+// Use this in tests that need to verify behaviour at a specific log level.
+func SDKRootWithLevel(ctx context.Context, output io.Writer, level hclog.Level) context.Context {
+	return tfsdklog.NewRootSDKLogger(
+		ctx,
+		logging.WithoutLocation(),
+		logging.WithoutTimestamp(),
+		logging.WithOutput(output),
+		tfsdklog.WithLevel(level),
+	)
+}
+
 // ProviderRootWithLevel creates a provider root logger at the given level.
 // Use this in tests that need to verify behaviour at a specific log level.
 func ProviderRootWithLevel(ctx context.Context, output io.Writer, level hclog.Level) context.Context {

--- a/tflog/provider.go
+++ b/tflog/provider.go
@@ -140,6 +140,51 @@ func Error(ctx context.Context, msg string, additionalFields ...map[string]inter
 	logger.Error(msg, additionalArgs...)
 }
 
+// IsTrace returns true if the logger in ctx would emit a trace-level log.
+func IsTrace(ctx context.Context) bool {
+	logger := logging.GetProviderRootLogger(ctx)
+	if logger == nil {
+		return false
+	}
+	return logger.IsTrace()
+}
+
+// IsDebug returns true if the logger in ctx would emit a debug-level log.
+func IsDebug(ctx context.Context) bool {
+	logger := logging.GetProviderRootLogger(ctx)
+	if logger == nil {
+		return false
+	}
+	return logger.IsDebug()
+}
+
+// IsInfo returns true if the logger in ctx would emit an info-level log.
+func IsInfo(ctx context.Context) bool {
+	logger := logging.GetProviderRootLogger(ctx)
+	if logger == nil {
+		return false
+	}
+	return logger.IsInfo()
+}
+
+// IsWarn returns true if the logger in ctx would emit a warn-level log.
+func IsWarn(ctx context.Context) bool {
+	logger := logging.GetProviderRootLogger(ctx)
+	if logger == nil {
+		return false
+	}
+	return logger.IsWarn()
+}
+
+// IsError returns true if the logger in ctx would emit an error-level log.
+func IsError(ctx context.Context) bool {
+	logger := logging.GetProviderRootLogger(ctx)
+	if logger == nil {
+		return false
+	}
+	return logger.IsError()
+}
+
 // OmitLogWithFieldKeys returns a new context.Context that has a modified logger
 // that will omit to write any log when any of the given keys is found
 // within its fields.

--- a/tflog/provider_example_test.go
+++ b/tflog/provider_example_test.go
@@ -365,3 +365,27 @@ func ExampleMaskLogStrings() {
 	// Output:
 	// {"@level":"trace","@message":"example log ***","@module":"provider","k1":"*** plus some text","k2":"*** plus more text"}
 }
+
+func ExampleIsTrace() {
+	// virtually no plugin developers will need to worry about
+	// instantiating loggers, as the libraries they're using will take care
+	// of that, but we're not using those libraries in these examples. So
+	// we need to do the injection ourselves. Plugin developers will
+	// basically never need to do this, so the next line can safely be
+	// considered setup for the example and ignored. Instead, use the
+	// context passed in by the framework or library you're using.
+	exampleCtx := getExampleContext()
+
+	// non-example-setup code begins here
+
+	// use IsTrace to skip building fields when trace logging is not enabled
+	if IsTrace(exampleCtx) {
+		fields := map[string]interface{}{
+			"computed-key": "computed-value",
+		}
+		Trace(exampleCtx, "hello, world", fields)
+	}
+
+	// Output:
+	// {"@level":"trace","@message":"hello, world","@module":"provider","computed-key":"computed-value"}
+}

--- a/tflog/provider_test.go
+++ b/tflog/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-log/internal/loggertest"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -1857,4 +1858,204 @@ func TestMaskLogStrings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsTrace(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"root-level-trace": {level: hclog.Trace, expected: true},
+		"root-level-debug": {level: hclog.Debug, expected: false},
+		"root-level-info":  {level: hclog.Info, expected: false},
+		"root-level-warn":  {level: hclog.Warn, expected: false},
+		"root-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRootWithLevel(ctx, &outputBuffer, testCase.level)
+
+			got := tflog.IsTrace(ctx)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-logger", func(t *testing.T) {
+		t.Parallel()
+
+		if got := tflog.IsTrace(context.Background()); got != false {
+			t.Errorf("expected false with no logger in context, got %v", got)
+		}
+	})
+}
+
+func TestIsDebug(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"root-level-trace": {level: hclog.Trace, expected: true},
+		"root-level-debug": {level: hclog.Debug, expected: true},
+		"root-level-info":  {level: hclog.Info, expected: false},
+		"root-level-warn":  {level: hclog.Warn, expected: false},
+		"root-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRootWithLevel(ctx, &outputBuffer, testCase.level)
+
+			got := tflog.IsDebug(ctx)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-logger", func(t *testing.T) {
+		t.Parallel()
+
+		if got := tflog.IsDebug(context.Background()); got != false {
+			t.Errorf("expected false with no logger in context, got %v", got)
+		}
+	})
+}
+
+func TestIsInfo(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"root-level-trace": {level: hclog.Trace, expected: true},
+		"root-level-debug": {level: hclog.Debug, expected: true},
+		"root-level-info":  {level: hclog.Info, expected: true},
+		"root-level-warn":  {level: hclog.Warn, expected: false},
+		"root-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRootWithLevel(ctx, &outputBuffer, testCase.level)
+
+			got := tflog.IsInfo(ctx)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-logger", func(t *testing.T) {
+		t.Parallel()
+
+		if got := tflog.IsInfo(context.Background()); got != false {
+			t.Errorf("expected false with no logger in context, got %v", got)
+		}
+	})
+}
+
+func TestIsWarn(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"root-level-trace": {level: hclog.Trace, expected: true},
+		"root-level-debug": {level: hclog.Debug, expected: true},
+		"root-level-info":  {level: hclog.Info, expected: true},
+		"root-level-warn":  {level: hclog.Warn, expected: true},
+		"root-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRootWithLevel(ctx, &outputBuffer, testCase.level)
+
+			got := tflog.IsWarn(ctx)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-logger", func(t *testing.T) {
+		t.Parallel()
+
+		if got := tflog.IsWarn(context.Background()); got != false {
+			t.Errorf("expected false with no logger in context, got %v", got)
+		}
+	})
+}
+
+func TestIsError(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"root-level-trace": {level: hclog.Trace, expected: true},
+		"root-level-debug": {level: hclog.Debug, expected: true},
+		"root-level-info":  {level: hclog.Info, expected: true},
+		"root-level-warn":  {level: hclog.Warn, expected: true},
+		"root-level-error": {level: hclog.Error, expected: true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRootWithLevel(ctx, &outputBuffer, testCase.level)
+
+			got := tflog.IsError(ctx)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-logger", func(t *testing.T) {
+		t.Parallel()
+
+		if got := tflog.IsError(context.Background()); got != false {
+			t.Errorf("expected false with no logger in context, got %v", got)
+		}
+	})
 }

--- a/tflog/subsystem.go
+++ b/tflog/subsystem.go
@@ -219,6 +219,51 @@ func SubsystemError(ctx context.Context, subsystem, msg string, additionalFields
 	logger.Error(msg, additionalArgs...)
 }
 
+// SubsystemIsTrace returns true if the subsystem logger in ctx would emit a trace-level log.
+func SubsystemIsTrace(ctx context.Context, subsystem string) bool {
+	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
+	if logger == nil {
+		return false
+	}
+	return logger.IsTrace()
+}
+
+// SubsystemIsDebug returns true if the subsystem logger in ctx would emit a debug-level log.
+func SubsystemIsDebug(ctx context.Context, subsystem string) bool {
+	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
+	if logger == nil {
+		return false
+	}
+	return logger.IsDebug()
+}
+
+// SubsystemIsInfo returns true if the subsystem logger in ctx would emit an info-level log.
+func SubsystemIsInfo(ctx context.Context, subsystem string) bool {
+	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
+	if logger == nil {
+		return false
+	}
+	return logger.IsInfo()
+}
+
+// SubsystemIsWarn returns true if the subsystem logger in ctx would emit a warn-level log.
+func SubsystemIsWarn(ctx context.Context, subsystem string) bool {
+	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
+	if logger == nil {
+		return false
+	}
+	return logger.IsWarn()
+}
+
+// SubsystemIsError returns true if the subsystem logger in ctx would emit an error-level log.
+func SubsystemIsError(ctx context.Context, subsystem string) bool {
+	logger := logging.GetProviderSubsystemLogger(ctx, subsystem)
+	if logger == nil {
+		return false
+	}
+	return logger.IsError()
+}
+
 // SubsystemOmitLogWithFieldKeys returns a new context.Context that has a modified logger
 // that will omit to write any log when any of the given keys is found
 // within its fields.

--- a/tflog/subsystem_example_test.go
+++ b/tflog/subsystem_example_test.go
@@ -442,3 +442,30 @@ func ExampleSubsystemMaskLogStrings() {
 	// Output:
 	// {"@level":"trace","@message":"example log ***","@module":"provider.my-subsystem","k1":"*** plus some text","k2":"*** plus more text"}
 }
+
+func ExampleSubsystemIsTrace() {
+	// virtually no plugin developers will need to worry about
+	// instantiating loggers, as the libraries they're using will take care
+	// of that, but we're not using those libraries in these examples. So
+	// we need to do the injection ourselves. Plugin developers will
+	// basically never need to do this, so the next line can safely be
+	// considered setup for the example and ignored. Instead, use the
+	// context passed in by the framework or library you're using.
+	exampleCtx := getExampleContext()
+
+	// register a new subsystem before using it
+	exampleCtx = NewSubsystem(exampleCtx, "my-subsystem")
+
+	// non-example-setup code begins here
+
+	// use SubsystemIsTrace to skip building fields when trace logging is not enabled
+	if SubsystemIsTrace(exampleCtx, "my-subsystem") {
+		fields := map[string]interface{}{
+			"computed-key": "computed-value",
+		}
+		SubsystemTrace(exampleCtx, "my-subsystem", "hello, world", fields)
+	}
+
+	// Output:
+	// {"@level":"trace","@message":"hello, world","@module":"provider.my-subsystem","computed-key":"computed-value"}
+}

--- a/tflog/subsystem_test.go
+++ b/tflog/subsystem_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-log/internal/loggertest"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -1885,4 +1886,234 @@ func TestSubsystemMaskLogStrings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubsystemIsTrace(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"subsystem-level-trace": {level: hclog.Trace, expected: true},
+		"subsystem-level-debug": {level: hclog.Debug, expected: false},
+		"subsystem-level-info":  {level: hclog.Info, expected: false},
+		"subsystem-level-warn":  {level: hclog.Warn, expected: false},
+		"subsystem-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem, tflog.WithLevel(testCase.level))
+
+			got := tflog.SubsystemIsTrace(ctx, testSubsystem)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-subsystem", func(t *testing.T) {
+		t.Parallel()
+
+		var outputBuffer bytes.Buffer
+
+		ctx := context.Background()
+		ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+
+		if got := tflog.SubsystemIsTrace(ctx, testSubsystem); got != false {
+			t.Errorf("expected false with no subsystem in context, got %v", got)
+		}
+	})
+}
+
+func TestSubsystemIsDebug(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"subsystem-level-trace": {level: hclog.Trace, expected: true},
+		"subsystem-level-debug": {level: hclog.Debug, expected: true},
+		"subsystem-level-info":  {level: hclog.Info, expected: false},
+		"subsystem-level-warn":  {level: hclog.Warn, expected: false},
+		"subsystem-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem, tflog.WithLevel(testCase.level))
+
+			got := tflog.SubsystemIsDebug(ctx, testSubsystem)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-subsystem", func(t *testing.T) {
+		t.Parallel()
+
+		var outputBuffer bytes.Buffer
+
+		ctx := context.Background()
+		ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+
+		if got := tflog.SubsystemIsDebug(ctx, testSubsystem); got != false {
+			t.Errorf("expected false with no subsystem in context, got %v", got)
+		}
+	})
+}
+
+func TestSubsystemIsInfo(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"subsystem-level-trace": {level: hclog.Trace, expected: true},
+		"subsystem-level-debug": {level: hclog.Debug, expected: true},
+		"subsystem-level-info":  {level: hclog.Info, expected: true},
+		"subsystem-level-warn":  {level: hclog.Warn, expected: false},
+		"subsystem-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem, tflog.WithLevel(testCase.level))
+
+			got := tflog.SubsystemIsInfo(ctx, testSubsystem)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-subsystem", func(t *testing.T) {
+		t.Parallel()
+
+		var outputBuffer bytes.Buffer
+
+		ctx := context.Background()
+		ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+
+		if got := tflog.SubsystemIsInfo(ctx, testSubsystem); got != false {
+			t.Errorf("expected false with no subsystem in context, got %v", got)
+		}
+	})
+}
+
+func TestSubsystemIsWarn(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"subsystem-level-trace": {level: hclog.Trace, expected: true},
+		"subsystem-level-debug": {level: hclog.Debug, expected: true},
+		"subsystem-level-info":  {level: hclog.Info, expected: true},
+		"subsystem-level-warn":  {level: hclog.Warn, expected: true},
+		"subsystem-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem, tflog.WithLevel(testCase.level))
+
+			got := tflog.SubsystemIsWarn(ctx, testSubsystem)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-subsystem", func(t *testing.T) {
+		t.Parallel()
+
+		var outputBuffer bytes.Buffer
+
+		ctx := context.Background()
+		ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+
+		if got := tflog.SubsystemIsWarn(ctx, testSubsystem); got != false {
+			t.Errorf("expected false with no subsystem in context, got %v", got)
+		}
+	})
+}
+
+func TestSubsystemIsError(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"subsystem-level-trace": {level: hclog.Trace, expected: true},
+		"subsystem-level-debug": {level: hclog.Debug, expected: true},
+		"subsystem-level-info":  {level: hclog.Info, expected: true},
+		"subsystem-level-warn":  {level: hclog.Warn, expected: true},
+		"subsystem-level-error": {level: hclog.Error, expected: true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+			ctx = tflog.NewSubsystem(ctx, testSubsystem, tflog.WithLevel(testCase.level))
+
+			got := tflog.SubsystemIsError(ctx, testSubsystem)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-subsystem", func(t *testing.T) {
+		t.Parallel()
+
+		var outputBuffer bytes.Buffer
+
+		ctx := context.Background()
+		ctx = loggertest.ProviderRoot(ctx, &outputBuffer)
+
+		if got := tflog.SubsystemIsError(ctx, testSubsystem); got != false {
+			t.Errorf("expected false with no subsystem in context, got %v", got)
+		}
+	})
 }

--- a/tfsdklog/sdk.go
+++ b/tfsdklog/sdk.go
@@ -231,6 +231,36 @@ func Error(ctx context.Context, msg string, additionalFields ...map[string]inter
 	logger.Error(msg, additionalArgs...)
 }
 
+// IsTrace returns true if the root SDK logger would emit a trace-level log.
+// The check is performed against a cached level for performance.
+func IsTrace(_ context.Context) bool {
+	return rootWouldLog(hclog.Trace)
+}
+
+// IsDebug returns true if the root SDK logger would emit a debug-level log.
+// The check is performed against a cached level for performance.
+func IsDebug(_ context.Context) bool {
+	return rootWouldLog(hclog.Debug)
+}
+
+// IsInfo returns true if the root SDK logger would emit an info-level log.
+// The check is performed against a cached level for performance.
+func IsInfo(_ context.Context) bool {
+	return rootWouldLog(hclog.Info)
+}
+
+// IsWarn returns true if the root SDK logger would emit a warn-level log.
+// The check is performed against a cached level for performance.
+func IsWarn(_ context.Context) bool {
+	return rootWouldLog(hclog.Warn)
+}
+
+// IsError returns true if the root SDK logger would emit an error-level log.
+// The check is performed against a cached level for performance.
+func IsError(_ context.Context) bool {
+	return rootWouldLog(hclog.Error)
+}
+
 // OmitLogWithFieldKeys returns a new context.Context that has a modified logger
 // that will omit to write any log when any of the given keys is found
 // within its fields.

--- a/tfsdklog/sdk_example_test.go
+++ b/tfsdklog/sdk_example_test.go
@@ -351,3 +351,25 @@ func ExampleMaskLogStrings() {
 	// Output:
 	// {"@level":"trace","@message":"example log ***","@module":"sdk","k1":"*** plus some text","k2":"*** plus more text"}
 }
+
+func ExampleIsTrace() {
+	// this function calls New with the options it needs to be reliably
+	// tested. Framework and SDK developers should call New, inject the
+	// resulting context in their framework, and then pass it around. This
+	// exampleCtx is a stand-in for a context you have injected a logger
+	// into and passed to the area of the codebase you need it.
+	exampleCtx := getExampleContext()
+
+	// non-example-setup code begins here
+
+	// use IsTrace to skip building fields when trace logging is not enabled
+	if IsTrace(exampleCtx) {
+		fields := map[string]interface{}{
+			"computed-key": "computed-value",
+		}
+		Trace(exampleCtx, "hello, world", fields)
+	}
+
+	// Output:
+	// {"@level":"trace","@message":"hello, world","@module":"sdk","computed-key":"computed-value"}
+}

--- a/tfsdklog/sdk_test.go
+++ b/tfsdklog/sdk_test.go
@@ -1860,142 +1860,72 @@ func TestMaskLogStrings(t *testing.T) {
 	}
 }
 
+// The IsXxx functions delegate to rootWouldLog which reads a package-level
+// cache set by NewRootSDKLogger. Running multiple subtests in parallel against
+// the same global is inherently racy (see TestRootWouldLog in levels_test.go
+// for the same pattern). Each test therefore uses a single representative case.
+
 func TestIsTrace(t *testing.T) {
-	testCases := map[string]struct {
-		level    hclog.Level
-		expected bool
-	}{
-		"root-level-trace": {level: hclog.Trace, expected: true},
-		"root-level-debug": {level: hclog.Debug, expected: false},
-		"root-level-info":  {level: hclog.Info, expected: false},
-		"root-level-warn":  {level: hclog.Warn, expected: false},
-		"root-level-error": {level: hclog.Error, expected: false},
-	}
+	t.Parallel()
 
-	for name, testCase := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var outputBuffer bytes.Buffer
+	var outputBuffer bytes.Buffer
 
-			ctx := context.Background()
-			ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, testCase.level)
+	ctx := context.Background()
+	ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, hclog.Trace)
 
-			got := tfsdklog.IsTrace(ctx)
-
-			if got != testCase.expected {
-				t.Errorf("expected %v, got %v", testCase.expected, got)
-			}
-		})
+	if !tfsdklog.IsTrace(ctx) {
+		t.Error("expected true when root level is trace")
 	}
 }
 
 func TestIsDebug(t *testing.T) {
-	testCases := map[string]struct {
-		level    hclog.Level
-		expected bool
-	}{
-		"root-level-trace": {level: hclog.Trace, expected: true},
-		"root-level-debug": {level: hclog.Debug, expected: true},
-		"root-level-info":  {level: hclog.Info, expected: false},
-		"root-level-warn":  {level: hclog.Warn, expected: false},
-		"root-level-error": {level: hclog.Error, expected: false},
-	}
+	t.Parallel()
 
-	for name, testCase := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var outputBuffer bytes.Buffer
+	var outputBuffer bytes.Buffer
 
-			ctx := context.Background()
-			ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, testCase.level)
+	ctx := context.Background()
+	ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, hclog.Debug)
 
-			got := tfsdklog.IsDebug(ctx)
-
-			if got != testCase.expected {
-				t.Errorf("expected %v, got %v", testCase.expected, got)
-			}
-		})
+	if !tfsdklog.IsDebug(ctx) {
+		t.Error("expected true when root level is debug")
 	}
 }
 
 func TestIsInfo(t *testing.T) {
-	testCases := map[string]struct {
-		level    hclog.Level
-		expected bool
-	}{
-		"root-level-trace": {level: hclog.Trace, expected: true},
-		"root-level-debug": {level: hclog.Debug, expected: true},
-		"root-level-info":  {level: hclog.Info, expected: true},
-		"root-level-warn":  {level: hclog.Warn, expected: false},
-		"root-level-error": {level: hclog.Error, expected: false},
-	}
+	t.Parallel()
 
-	for name, testCase := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var outputBuffer bytes.Buffer
+	var outputBuffer bytes.Buffer
 
-			ctx := context.Background()
-			ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, testCase.level)
+	ctx := context.Background()
+	ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, hclog.Info)
 
-			got := tfsdklog.IsInfo(ctx)
-
-			if got != testCase.expected {
-				t.Errorf("expected %v, got %v", testCase.expected, got)
-			}
-		})
+	if !tfsdklog.IsInfo(ctx) {
+		t.Error("expected true when root level is info")
 	}
 }
 
 func TestIsWarn(t *testing.T) {
-	testCases := map[string]struct {
-		level    hclog.Level
-		expected bool
-	}{
-		"root-level-trace": {level: hclog.Trace, expected: true},
-		"root-level-debug": {level: hclog.Debug, expected: true},
-		"root-level-info":  {level: hclog.Info, expected: true},
-		"root-level-warn":  {level: hclog.Warn, expected: true},
-		"root-level-error": {level: hclog.Error, expected: false},
-	}
+	t.Parallel()
 
-	for name, testCase := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var outputBuffer bytes.Buffer
+	var outputBuffer bytes.Buffer
 
-			ctx := context.Background()
-			ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, testCase.level)
+	ctx := context.Background()
+	ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, hclog.Warn)
 
-			got := tfsdklog.IsWarn(ctx)
-
-			if got != testCase.expected {
-				t.Errorf("expected %v, got %v", testCase.expected, got)
-			}
-		})
+	if !tfsdklog.IsWarn(ctx) {
+		t.Error("expected true when root level is warn")
 	}
 }
 
 func TestIsError(t *testing.T) {
-	testCases := map[string]struct {
-		level    hclog.Level
-		expected bool
-	}{
-		"root-level-trace": {level: hclog.Trace, expected: true},
-		"root-level-debug": {level: hclog.Debug, expected: true},
-		"root-level-info":  {level: hclog.Info, expected: true},
-		"root-level-warn":  {level: hclog.Warn, expected: true},
-		"root-level-error": {level: hclog.Error, expected: true},
-	}
+	t.Parallel()
 
-	for name, testCase := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var outputBuffer bytes.Buffer
+	var outputBuffer bytes.Buffer
 
-			ctx := context.Background()
-			ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, testCase.level)
+	ctx := context.Background()
+	ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, hclog.Error)
 
-			got := tfsdklog.IsError(ctx)
-
-			if got != testCase.expected {
-				t.Errorf("expected %v, got %v", testCase.expected, got)
-			}
-		})
+	if !tfsdklog.IsError(ctx) {
+		t.Error("expected true when root level is error")
 	}
 }

--- a/tfsdklog/sdk_test.go
+++ b/tfsdklog/sdk_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-log/internal/loggertest"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 )
@@ -1854,6 +1855,146 @@ func TestMaskLogStrings(t *testing.T) {
 
 			if diff := cmp.Diff(testCase.expectedOutput, got); diff != "" {
 				t.Errorf("unexpected output difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestIsTrace(t *testing.T) {
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"root-level-trace": {level: hclog.Trace, expected: true},
+		"root-level-debug": {level: hclog.Debug, expected: false},
+		"root-level-info":  {level: hclog.Info, expected: false},
+		"root-level-warn":  {level: hclog.Warn, expected: false},
+		"root-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, testCase.level)
+
+			got := tfsdklog.IsTrace(ctx)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+}
+
+func TestIsDebug(t *testing.T) {
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"root-level-trace": {level: hclog.Trace, expected: true},
+		"root-level-debug": {level: hclog.Debug, expected: true},
+		"root-level-info":  {level: hclog.Info, expected: false},
+		"root-level-warn":  {level: hclog.Warn, expected: false},
+		"root-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, testCase.level)
+
+			got := tfsdklog.IsDebug(ctx)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+}
+
+func TestIsInfo(t *testing.T) {
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"root-level-trace": {level: hclog.Trace, expected: true},
+		"root-level-debug": {level: hclog.Debug, expected: true},
+		"root-level-info":  {level: hclog.Info, expected: true},
+		"root-level-warn":  {level: hclog.Warn, expected: false},
+		"root-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, testCase.level)
+
+			got := tfsdklog.IsInfo(ctx)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+}
+
+func TestIsWarn(t *testing.T) {
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"root-level-trace": {level: hclog.Trace, expected: true},
+		"root-level-debug": {level: hclog.Debug, expected: true},
+		"root-level-info":  {level: hclog.Info, expected: true},
+		"root-level-warn":  {level: hclog.Warn, expected: true},
+		"root-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, testCase.level)
+
+			got := tfsdklog.IsWarn(ctx)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+}
+
+func TestIsError(t *testing.T) {
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"root-level-trace": {level: hclog.Trace, expected: true},
+		"root-level-debug": {level: hclog.Debug, expected: true},
+		"root-level-info":  {level: hclog.Info, expected: true},
+		"root-level-warn":  {level: hclog.Warn, expected: true},
+		"root-level-error": {level: hclog.Error, expected: true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRootWithLevel(ctx, &outputBuffer, testCase.level)
+
+			got := tfsdklog.IsError(ctx)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
 			}
 		})
 	}

--- a/tfsdklog/subsystem.go
+++ b/tfsdklog/subsystem.go
@@ -246,6 +246,36 @@ func SubsystemError(ctx context.Context, subsystem, msg string, additionalFields
 	logger.Error(msg, additionalArgs...)
 }
 
+// SubsystemIsTrace returns true if the subsystem SDK logger would emit a trace-level log.
+// The check is performed against a cached level for performance.
+func SubsystemIsTrace(_ context.Context, subsystem string) bool {
+	return subsystemWouldLog(subsystem, hclog.Trace)
+}
+
+// SubsystemIsDebug returns true if the subsystem SDK logger would emit a debug-level log.
+// The check is performed against a cached level for performance.
+func SubsystemIsDebug(_ context.Context, subsystem string) bool {
+	return subsystemWouldLog(subsystem, hclog.Debug)
+}
+
+// SubsystemIsInfo returns true if the subsystem SDK logger would emit an info-level log.
+// The check is performed against a cached level for performance.
+func SubsystemIsInfo(_ context.Context, subsystem string) bool {
+	return subsystemWouldLog(subsystem, hclog.Info)
+}
+
+// SubsystemIsWarn returns true if the subsystem SDK logger would emit a warn-level log.
+// The check is performed against a cached level for performance.
+func SubsystemIsWarn(_ context.Context, subsystem string) bool {
+	return subsystemWouldLog(subsystem, hclog.Warn)
+}
+
+// SubsystemIsError returns true if the subsystem SDK logger would emit an error-level log.
+// The check is performed against a cached level for performance.
+func SubsystemIsError(_ context.Context, subsystem string) bool {
+	return subsystemWouldLog(subsystem, hclog.Error)
+}
+
 // SubsystemOmitLogWithFieldKeys returns a new context.Context that has a modified logger
 // that will omit to write any log when any of the given keys is found
 // within its fields.

--- a/tfsdklog/subsystem_example_test.go
+++ b/tfsdklog/subsystem_example_test.go
@@ -408,3 +408,28 @@ func ExampleSubsystemMaskLogStrings() {
 	// Output:
 	// {"@level":"trace","@message":"example log ***","@module":"sdk.my-subsystem","k1":"*** plus some text","k2":"*** plus more text"}
 }
+
+func ExampleSubsystemIsTrace() {
+	// this function calls new with the options it needs to be reliably
+	// tested. framework and sdk developers should call new, inject the
+	// resulting context in their framework, and then pass it around. this
+	// examplectx is a stand-in for a context you have injected a logger
+	// into and passed to the area of the codebase you need it.
+	exampleCtx := getExampleContext()
+
+	// register a new subsystem before using it
+	exampleCtx = NewSubsystem(exampleCtx, "my-subsystem")
+
+	// non-example-setup code begins here
+
+	// use SubsystemIsTrace to skip building fields when trace logging is not enabled
+	if SubsystemIsTrace(exampleCtx, "my-subsystem") {
+		fields := map[string]interface{}{
+			"computed-key": "computed-value",
+		}
+		SubsystemTrace(exampleCtx, "my-subsystem", "hello, world", fields)
+	}
+
+	// Output:
+	// {"@level":"trace","@message":"hello, world","@module":"sdk.my-subsystem","computed-key":"computed-value"}
+}

--- a/tfsdklog/subsystem_test.go
+++ b/tfsdklog/subsystem_test.go
@@ -1908,3 +1908,203 @@ func TestSubsystemMaskLogStrings(t *testing.T) {
 		})
 	}
 }
+
+func TestSubsystemIsTrace(t *testing.T) {
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"subsystem-level-trace": {level: hclog.Trace, expected: true},
+		"subsystem-level-debug": {level: hclog.Debug, expected: false},
+		"subsystem-level-info":  {level: hclog.Info, expected: false},
+		"subsystem-level-warn":  {level: hclog.Warn, expected: false},
+		"subsystem-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem, tfsdklog.WithLevel(testCase.level))
+
+			got := tfsdklog.SubsystemIsTrace(ctx, testSubsystem)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-subsystem", func(t *testing.T) {
+		var outputBuffer bytes.Buffer
+
+		ctx := context.Background()
+		ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+
+		if got := tfsdklog.SubsystemIsTrace(ctx, "unregistered_subsystem"); got != false {
+			t.Errorf("expected false with unregistered subsystem, got %v", got)
+		}
+	})
+}
+
+func TestSubsystemIsDebug(t *testing.T) {
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"subsystem-level-trace": {level: hclog.Trace, expected: true},
+		"subsystem-level-debug": {level: hclog.Debug, expected: true},
+		"subsystem-level-info":  {level: hclog.Info, expected: false},
+		"subsystem-level-warn":  {level: hclog.Warn, expected: false},
+		"subsystem-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem, tfsdklog.WithLevel(testCase.level))
+
+			got := tfsdklog.SubsystemIsDebug(ctx, testSubsystem)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-subsystem", func(t *testing.T) {
+		var outputBuffer bytes.Buffer
+
+		ctx := context.Background()
+		ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+
+		if got := tfsdklog.SubsystemIsDebug(ctx, "unregistered_subsystem"); got != false {
+			t.Errorf("expected false with unregistered subsystem, got %v", got)
+		}
+	})
+}
+
+func TestSubsystemIsInfo(t *testing.T) {
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"subsystem-level-trace": {level: hclog.Trace, expected: true},
+		"subsystem-level-debug": {level: hclog.Debug, expected: true},
+		"subsystem-level-info":  {level: hclog.Info, expected: true},
+		"subsystem-level-warn":  {level: hclog.Warn, expected: false},
+		"subsystem-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem, tfsdklog.WithLevel(testCase.level))
+
+			got := tfsdklog.SubsystemIsInfo(ctx, testSubsystem)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-subsystem", func(t *testing.T) {
+		var outputBuffer bytes.Buffer
+
+		ctx := context.Background()
+		ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+
+		if got := tfsdklog.SubsystemIsInfo(ctx, "unregistered_subsystem"); got != false {
+			t.Errorf("expected false with unregistered subsystem, got %v", got)
+		}
+	})
+}
+
+func TestSubsystemIsWarn(t *testing.T) {
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"subsystem-level-trace": {level: hclog.Trace, expected: true},
+		"subsystem-level-debug": {level: hclog.Debug, expected: true},
+		"subsystem-level-info":  {level: hclog.Info, expected: true},
+		"subsystem-level-warn":  {level: hclog.Warn, expected: true},
+		"subsystem-level-error": {level: hclog.Error, expected: false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem, tfsdklog.WithLevel(testCase.level))
+
+			got := tfsdklog.SubsystemIsWarn(ctx, testSubsystem)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-subsystem", func(t *testing.T) {
+		var outputBuffer bytes.Buffer
+
+		ctx := context.Background()
+		ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+
+		if got := tfsdklog.SubsystemIsWarn(ctx, "unregistered_subsystem"); got != false {
+			t.Errorf("expected false with unregistered subsystem, got %v", got)
+		}
+	})
+}
+
+func TestSubsystemIsError(t *testing.T) {
+	testCases := map[string]struct {
+		level    hclog.Level
+		expected bool
+	}{
+		"subsystem-level-trace": {level: hclog.Trace, expected: true},
+		"subsystem-level-debug": {level: hclog.Debug, expected: true},
+		"subsystem-level-info":  {level: hclog.Info, expected: true},
+		"subsystem-level-warn":  {level: hclog.Warn, expected: true},
+		"subsystem-level-error": {level: hclog.Error, expected: true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+
+			ctx := context.Background()
+			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem, tfsdklog.WithLevel(testCase.level))
+
+			got := tfsdklog.SubsystemIsError(ctx, testSubsystem)
+
+			if got != testCase.expected {
+				t.Errorf("expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+
+	t.Run("no-subsystem", func(t *testing.T) {
+		var outputBuffer bytes.Buffer
+
+		ctx := context.Background()
+		ctx = loggertest.SDKRoot(ctx, &outputBuffer)
+
+		if got := tfsdklog.SubsystemIsError(ctx, "unregistered_subsystem"); got != false {
+			t.Errorf("expected false with unregistered subsystem, got %v", got)
+		}
+	})
+}

--- a/tfsdklog/subsystem_test.go
+++ b/tfsdklog/subsystem_test.go
@@ -1910,6 +1910,8 @@ func TestSubsystemMaskLogStrings(t *testing.T) {
 }
 
 func TestSubsystemIsTrace(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		level    hclog.Level
 		expected bool
@@ -1923,13 +1925,15 @@ func TestSubsystemIsTrace(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			var outputBuffer bytes.Buffer
 
 			ctx := context.Background()
 			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
-			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem, tfsdklog.WithLevel(testCase.level))
+			ctx = tfsdklog.NewSubsystem(ctx, t.Name(), tfsdklog.WithLevel(testCase.level))
 
-			got := tfsdklog.SubsystemIsTrace(ctx, testSubsystem)
+			got := tfsdklog.SubsystemIsTrace(ctx, t.Name())
 
 			if got != testCase.expected {
 				t.Errorf("expected %v, got %v", testCase.expected, got)
@@ -1938,18 +1942,22 @@ func TestSubsystemIsTrace(t *testing.T) {
 	}
 
 	t.Run("no-subsystem", func(t *testing.T) {
+		t.Parallel()
+
 		var outputBuffer bytes.Buffer
 
 		ctx := context.Background()
 		ctx = loggertest.SDKRoot(ctx, &outputBuffer)
 
-		if got := tfsdklog.SubsystemIsTrace(ctx, "unregistered_subsystem"); got != false {
+		if got := tfsdklog.SubsystemIsTrace(ctx, t.Name()); got != false {
 			t.Errorf("expected false with unregistered subsystem, got %v", got)
 		}
 	})
 }
 
 func TestSubsystemIsDebug(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		level    hclog.Level
 		expected bool
@@ -1963,13 +1971,15 @@ func TestSubsystemIsDebug(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			var outputBuffer bytes.Buffer
 
 			ctx := context.Background()
 			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
-			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem, tfsdklog.WithLevel(testCase.level))
+			ctx = tfsdklog.NewSubsystem(ctx, t.Name(), tfsdklog.WithLevel(testCase.level))
 
-			got := tfsdklog.SubsystemIsDebug(ctx, testSubsystem)
+			got := tfsdklog.SubsystemIsDebug(ctx, t.Name())
 
 			if got != testCase.expected {
 				t.Errorf("expected %v, got %v", testCase.expected, got)
@@ -1978,18 +1988,22 @@ func TestSubsystemIsDebug(t *testing.T) {
 	}
 
 	t.Run("no-subsystem", func(t *testing.T) {
+		t.Parallel()
+
 		var outputBuffer bytes.Buffer
 
 		ctx := context.Background()
 		ctx = loggertest.SDKRoot(ctx, &outputBuffer)
 
-		if got := tfsdklog.SubsystemIsDebug(ctx, "unregistered_subsystem"); got != false {
+		if got := tfsdklog.SubsystemIsDebug(ctx, t.Name()); got != false {
 			t.Errorf("expected false with unregistered subsystem, got %v", got)
 		}
 	})
 }
 
 func TestSubsystemIsInfo(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		level    hclog.Level
 		expected bool
@@ -2003,13 +2017,15 @@ func TestSubsystemIsInfo(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			var outputBuffer bytes.Buffer
 
 			ctx := context.Background()
 			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
-			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem, tfsdklog.WithLevel(testCase.level))
+			ctx = tfsdklog.NewSubsystem(ctx, t.Name(), tfsdklog.WithLevel(testCase.level))
 
-			got := tfsdklog.SubsystemIsInfo(ctx, testSubsystem)
+			got := tfsdklog.SubsystemIsInfo(ctx, t.Name())
 
 			if got != testCase.expected {
 				t.Errorf("expected %v, got %v", testCase.expected, got)
@@ -2018,18 +2034,22 @@ func TestSubsystemIsInfo(t *testing.T) {
 	}
 
 	t.Run("no-subsystem", func(t *testing.T) {
+		t.Parallel()
+
 		var outputBuffer bytes.Buffer
 
 		ctx := context.Background()
 		ctx = loggertest.SDKRoot(ctx, &outputBuffer)
 
-		if got := tfsdklog.SubsystemIsInfo(ctx, "unregistered_subsystem"); got != false {
+		if got := tfsdklog.SubsystemIsInfo(ctx, t.Name()); got != false {
 			t.Errorf("expected false with unregistered subsystem, got %v", got)
 		}
 	})
 }
 
 func TestSubsystemIsWarn(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		level    hclog.Level
 		expected bool
@@ -2043,13 +2063,15 @@ func TestSubsystemIsWarn(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			var outputBuffer bytes.Buffer
 
 			ctx := context.Background()
 			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
-			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem, tfsdklog.WithLevel(testCase.level))
+			ctx = tfsdklog.NewSubsystem(ctx, t.Name(), tfsdklog.WithLevel(testCase.level))
 
-			got := tfsdklog.SubsystemIsWarn(ctx, testSubsystem)
+			got := tfsdklog.SubsystemIsWarn(ctx, t.Name())
 
 			if got != testCase.expected {
 				t.Errorf("expected %v, got %v", testCase.expected, got)
@@ -2058,18 +2080,22 @@ func TestSubsystemIsWarn(t *testing.T) {
 	}
 
 	t.Run("no-subsystem", func(t *testing.T) {
+		t.Parallel()
+
 		var outputBuffer bytes.Buffer
 
 		ctx := context.Background()
 		ctx = loggertest.SDKRoot(ctx, &outputBuffer)
 
-		if got := tfsdklog.SubsystemIsWarn(ctx, "unregistered_subsystem"); got != false {
+		if got := tfsdklog.SubsystemIsWarn(ctx, t.Name()); got != false {
 			t.Errorf("expected false with unregistered subsystem, got %v", got)
 		}
 	})
 }
 
 func TestSubsystemIsError(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		level    hclog.Level
 		expected bool
@@ -2083,13 +2109,15 @@ func TestSubsystemIsError(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			var outputBuffer bytes.Buffer
 
 			ctx := context.Background()
 			ctx = loggertest.SDKRoot(ctx, &outputBuffer)
-			ctx = tfsdklog.NewSubsystem(ctx, testSubsystem, tfsdklog.WithLevel(testCase.level))
+			ctx = tfsdklog.NewSubsystem(ctx, t.Name(), tfsdklog.WithLevel(testCase.level))
 
-			got := tfsdklog.SubsystemIsError(ctx, testSubsystem)
+			got := tfsdklog.SubsystemIsError(ctx, t.Name())
 
 			if got != testCase.expected {
 				t.Errorf("expected %v, got %v", testCase.expected, got)
@@ -2098,12 +2126,14 @@ func TestSubsystemIsError(t *testing.T) {
 	}
 
 	t.Run("no-subsystem", func(t *testing.T) {
+		t.Parallel()
+
 		var outputBuffer bytes.Buffer
 
 		ctx := context.Background()
 		ctx = loggertest.SDKRoot(ctx, &outputBuffer)
 
-		if got := tfsdklog.SubsystemIsError(ctx, "unregistered_subsystem"); got != false {
+		if got := tfsdklog.SubsystemIsError(ctx, t.Name()); got != false {
 			t.Errorf("expected false with unregistered subsystem, got %v", got)
 		}
 	})


### PR DESCRIPTION
## Related Issue

Fixes #298

## Description

Adds log level guard functions for Provider and SDK logging for default and subsystem loggers.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No.
