### PR TITLE
Add the 0.11.0 log level guard functions to the changelog

### DIFF
--- a/.changes/0.11.0.md
+++ b/.changes/0.11.0.md
@@ -4,3 +4,10 @@ NOTES:
 
 * This Go module has been updated to Go 1.25 per the [Go support policy](https://golang.org/doc/devel/release.html#policy). Any consumers building on earlier Go versions may experience errors. ([#285](https://github.com/hashicorp/terraform-plugin-log/issues/285))
 
+ENHANCEMENTS:
+
+* tflog: Added `IsTrace()`, `IsDebug()`, `IsInfo()`, `IsWarn()` and `IsError()` functions, which report whether the provider root logger would emit a log at the given level ([#299](https://github.com/hashicorp/terraform-plugin-log/issues/299))
+* tflog: Added `SubsystemIsTrace()`, `SubsystemIsDebug()`, `SubsystemIsInfo()`, `SubsystemIsWarn()` and `SubsystemIsError()` functions, which report whether a provider subsystem logger would emit a log at the given level ([#299](https://github.com/hashicorp/terraform-plugin-log/issues/299))
+* tfsdklog: Added `IsTrace()`, `IsDebug()`, `IsInfo()`, `IsWarn()` and `IsError()` functions, which report whether the root SDK logger would emit a log at the given level ([#299](https://github.com/hashicorp/terraform-plugin-log/issues/299))
+* tfsdklog: Added `SubsystemIsTrace()`, `SubsystemIsDebug()`, `SubsystemIsInfo()`, `SubsystemIsWarn()` and `SubsystemIsError()` functions, which report whether an SDK subsystem logger would emit a log at the given level ([#299](https://github.com/hashicorp/terraform-plugin-log/issues/299))
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ NOTES:
 
 * This Go module has been updated to Go 1.25 per the [Go support policy](https://golang.org/doc/devel/release.html#policy). Any consumers building on earlier Go versions may experience errors. ([#285](https://github.com/hashicorp/terraform-plugin-log/issues/285))
 
+ENHANCEMENTS:
+
+* tflog: Added `IsTrace()`, `IsDebug()`, `IsInfo()`, `IsWarn()` and `IsError()` functions, which report whether the provider root logger would emit a log at the given level ([#299](https://github.com/hashicorp/terraform-plugin-log/issues/299))
+* tflog: Added `SubsystemIsTrace()`, `SubsystemIsDebug()`, `SubsystemIsInfo()`, `SubsystemIsWarn()` and `SubsystemIsError()` functions, which report whether a provider subsystem logger would emit a log at the given level ([#299](https://github.com/hashicorp/terraform-plugin-log/issues/299))
+* tfsdklog: Added `IsTrace()`, `IsDebug()`, `IsInfo()`, `IsWarn()` and `IsError()` functions, which report whether the root SDK logger would emit a log at the given level ([#299](https://github.com/hashicorp/terraform-plugin-log/issues/299))
+* tfsdklog: Added `SubsystemIsTrace()`, `SubsystemIsDebug()`, `SubsystemIsInfo()`, `SubsystemIsWarn()` and `SubsystemIsError()` functions, which report whether an SDK subsystem logger would emit a log at the given level ([#299](https://github.com/hashicorp/terraform-plugin-log/issues/299))
+
 ## 0.10.0 (November 13, 2025)
 
 NOTES:


### PR DESCRIPTION
## Related Issue

No issue filed. This is a follow-up to #299, whose additions are missing from the 0.11.0 changelog.

## Description

#299 added twenty exported functions in 0.11.0 -- `IsTrace`, `IsDebug`, `IsInfo`, `IsWarn`, `IsError` and their `SubsystemIs*` counterparts, in both `tflog` and `tfsdklog` -- but did not carry a `.changes/unreleased` fragment. changie batches only what is in that directory, and the release commit (dbd9e7e) consumed a single fragment, `NOTES-20260305-101442.yaml`, for the Go 1.25 bump. The published 0.11.0 notes therefore describe the release as a Go version bump alone, with no indication that new public API landed.

I noticed this while triaging the v0.10.0 -> v0.11.0 bump for a Terraform provider. The release notes suggested there was nothing to evaluate beyond the Go floor, whereas the tag actually contains a new capability worth knowing about.

This PR adds the missing entries to the already-released 0.11.0 section, in both `CHANGELOG.md` and `.changes/0.11.0.md`, rather than adding an unreleased fragment. The functions shipped in 0.11.0, so filing them under the next release would substitute one incorrect version attribution for another. Nothing is added to `.changes/unreleased/`, so the next `changie batch` is unaffected.

**On the kind chosen.** I used `ENHANCEMENTS`, following the CONTRIBUTING guidance, which reserves `FEATURES` for a new package and gives the sub-package-prefixed form (`attr: Added ...`) as the enhancement example. Worth flagging that 0.5.0 (#71) and 0.7.0 (#87) placed closely comparable entries under `FEATURES` -- the omission and masking filter families, also root and subsystem variants across both packages. Happy to switch if you would rather be consistent with those.

The function list was verified against the published module zips for both versions rather than the compare view: v0.10.0 exports none of these, v0.11.0 exports all twenty.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None. Documentation only -- no code, tests, or build configuration are touched.
